### PR TITLE
Admin page Enhancements

### DIFF
--- a/design/deployment.md
+++ b/design/deployment.md
@@ -9,6 +9,16 @@
 
 ### Frontend only (current)
 
+**1. Create your local env file**
+
+```bash
+cp src/web/.env.example src/web/.env.local
+```
+
+Edit `src/web/.env.local` and set `VITE_DEV_AUTH_USERNAME` to your GitHub username. This mocks authentication locally — without it you'll be redirected to `/unauthorized` when visiting `/admin`.
+
+**2. Start the dev server**
+
 ```bash
 cd src/web
 npm install

--- a/src/api/package.json
+++ b/src/api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "story-time-api",
+  "name": "wistful-me-api",
   "version": "1.0.0",
   "scripts": {
     "build": "tsc",

--- a/src/web/.env.example
+++ b/src/web/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env.local and fill in your values.
+# .env.local is gitignored and never committed.
+
+# Your GitHub username — used to mock authentication in local dev.
+VITE_DEV_AUTH_USERNAME=your-github-username

--- a/src/web/.gitignore
+++ b/src/web/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+.vite
 
 # Editor directories and files
 .vscode/*

--- a/src/web/.vite/deps/_metadata.json
+++ b/src/web/.vite/deps/_metadata.json
@@ -2,7 +2,75 @@
   "hash": "c85fe6ff",
   "configHash": "5f7e50db",
   "lockfileHash": "58b4b707",
-  "browserHash": "0bd6e4bf",
-  "optimized": {},
-  "chunks": {}
+  "browserHash": "dce2d231",
+  "optimized": {
+    "@dnd-kit/core": {
+      "src": "../../node_modules/@dnd-kit/core/dist/core.esm.js",
+      "file": "@dnd-kit_core.js",
+      "fileHash": "38c32493",
+      "needsInterop": false
+    },
+    "@dnd-kit/sortable": {
+      "src": "../../node_modules/@dnd-kit/sortable/dist/sortable.esm.js",
+      "file": "@dnd-kit_sortable.js",
+      "fileHash": "7ca1c2fd",
+      "needsInterop": false
+    },
+    "@dnd-kit/utilities": {
+      "src": "../../node_modules/@dnd-kit/utilities/dist/utilities.esm.js",
+      "file": "@dnd-kit_utilities.js",
+      "fileHash": "b69b199c",
+      "needsInterop": false
+    },
+    "react-dom/client": {
+      "src": "../../node_modules/react-dom/client.js",
+      "file": "react-dom_client.js",
+      "fileHash": "a26d49d8",
+      "needsInterop": true
+    },
+    "react-markdown": {
+      "src": "../../node_modules/react-markdown/index.js",
+      "file": "react-markdown.js",
+      "fileHash": "49b412ca",
+      "needsInterop": false
+    },
+    "react-router-dom": {
+      "src": "../../node_modules/react-router-dom/dist/index.mjs",
+      "file": "react-router-dom.js",
+      "fileHash": "895c0294",
+      "needsInterop": false
+    },
+    "react-swipeable": {
+      "src": "../../node_modules/react-swipeable/es/index.js",
+      "file": "react-swipeable.js",
+      "fileHash": "1e788172",
+      "needsInterop": false
+    },
+    "react": {
+      "src": "../../node_modules/react/index.js",
+      "file": "react.js",
+      "fileHash": "54ae237e",
+      "needsInterop": true
+    },
+    "react/jsx-dev-runtime": {
+      "src": "../../node_modules/react/jsx-dev-runtime.js",
+      "file": "react_jsx-dev-runtime.js",
+      "fileHash": "4705292a",
+      "needsInterop": true
+    }
+  },
+  "chunks": {
+    "core.esm-PeB9Gjgm": {
+      "file": "core.esm-PeB9Gjgm.js",
+      "isDynamicEntry": false
+    },
+    "react-BDWiK9rz": {
+      "file": "react-BDWiK9rz.js",
+      "isDynamicEntry": false
+    },
+    "react-dom-CQ09sKIc": {
+      "file": "react-dom-CQ09sKIc.js",
+      "isDynamicEntry": false
+    }
+  }
 }

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Story Time</title>
+    <title>Wistful.Me</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&family=Lora:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet" />

--- a/src/web/src/api/auth.ts
+++ b/src/web/src/api/auth.ts
@@ -1,0 +1,22 @@
+export interface AuthUser {
+  username: string;
+  userId: string;
+}
+
+export async function getAuthUser(): Promise<AuthUser | null> {
+  if (import.meta.env.DEV) {
+    const username = import.meta.env.VITE_DEV_AUTH_USERNAME as string | undefined;
+    if (!username) return null;
+    return { username, userId: username };
+  }
+  try {
+    const res = await fetch('/.auth/me');
+    if (!res.ok) return null;
+    const data = await res.json();
+    const principal = data?.clientPrincipal;
+    if (!principal) return null;
+    return { username: principal.userDetails as string, userId: principal.userId as string };
+  } catch {
+    return null;
+  }
+}

--- a/src/web/src/api/index.ts
+++ b/src/web/src/api/index.ts
@@ -1,4 +1,4 @@
-import type { Story, Chapter } from '../types';
+import type { Story, Chapter, AdminUser } from '../types';
 
 const INITIAL_STORIES: Story[] = [
   {
@@ -61,6 +61,61 @@ function saveContent(m: Map<string, string>): void {
 
 let stories: Story[] = loadStories();
 const mockContent: Map<string, string> = loadContent();
+
+// ── Admin whitelist ──────────────────────────────────────────────────────────
+
+const INITIAL_ADMINS: AdminUser[] = [
+  { id: 'admin-1', username: 'kelsi-jane', isPrimary: true, addedAt: '2026-01-01T00:00:00Z' },
+];
+
+const ADMINS_KEY = 'st-mock-admins';
+
+function loadAdmins(): AdminUser[] {
+  try {
+    const raw = localStorage.getItem(ADMINS_KEY);
+    if (raw) return JSON.parse(raw) as AdminUser[];
+  } catch {}
+  return [...INITIAL_ADMINS];
+}
+
+function saveAdmins(a: AdminUser[]): void {
+  localStorage.setItem(ADMINS_KEY, JSON.stringify(a));
+}
+
+let admins: AdminUser[] = loadAdmins();
+
+export async function getAdmins(): Promise<AdminUser[]> {
+  return admins;
+}
+
+export async function isAdminUser(username: string): Promise<AdminUser | null> {
+  return admins.find((a) => a.username.toLowerCase() === username.toLowerCase()) ?? null;
+}
+
+export async function addAdmin(username: string): Promise<AdminUser> {
+  if (admins.find((a) => a.username.toLowerCase() === username.toLowerCase())) {
+    throw new Error('User is already an admin');
+  }
+  const admin: AdminUser = { id: crypto.randomUUID(), username, isPrimary: false, addedAt: new Date().toISOString() };
+  admins = [...admins, admin];
+  saveAdmins(admins);
+  return admin;
+}
+
+export async function removeAdmin(id: string): Promise<void> {
+  const target = admins.find((a) => a.id === id);
+  if (!target) throw new Error('Admin not found');
+  if (target.isPrimary) throw new Error('Cannot remove the primary admin');
+  admins = admins.filter((a) => a.id !== id);
+  saveAdmins(admins);
+}
+
+export async function transferPrimary(toId: string): Promise<void> {
+  const target = admins.find((a) => a.id === toId);
+  if (!target) throw new Error('Admin not found');
+  admins = admins.map((a) => ({ ...a, isPrimary: a.id === toId }));
+  saveAdmins(admins);
+}
 
 // ── Read ────────────────────────────────────────────────────────────────────
 

--- a/src/web/src/components/AdminLayout.tsx
+++ b/src/web/src/components/AdminLayout.tsx
@@ -1,4 +1,6 @@
-import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 interface Props {
   children: React.ReactNode;
@@ -6,11 +8,26 @@ interface Props {
 }
 
 export default function AdminLayout({ children, breadcrumb }: Props) {
+  const { isAdmin, isPrimary, loading } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!loading && !isAdmin) navigate('/unauthorized', { replace: true });
+  }, [loading, isAdmin, navigate]);
+
+  if (loading) return (
+    <div style={{ minHeight: '100vh', background: 'var(--color-background)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+      <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 14, color: 'var(--color-text-secondary)' }}>Loading…</span>
+    </div>
+  );
+
+  if (!isAdmin) return null;
+
   return (
     <div style={styles.shell}>
       <header style={styles.header}>
         <nav style={styles.nav}>
-          <Link to="/" style={styles.siteLink}>Story Time</Link>
+          <Link to="/" style={styles.siteLink}>Wistful.Me</Link>
           <span style={styles.separator}>/</span>
           <Link to="/admin" style={styles.adminLink}>Admin</Link>
           {breadcrumb && (
@@ -20,6 +37,17 @@ export default function AdminLayout({ children, breadcrumb }: Props) {
             </>
           )}
         </nav>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
+          {isPrimary && (
+            <Link to="/admin/admins" style={styles.headerLink}>Manage admins</Link>
+          )}
+          <a
+            href={import.meta.env.DEV ? '/' : '/.auth/logout?post_logout_redirect_uri=/'}
+            style={styles.headerLink}
+          >
+            Sign out
+          </a>
+        </div>
       </header>
       <main style={styles.main}>{children}</main>
     </div>
@@ -38,6 +66,7 @@ const styles: Record<string, React.CSSProperties> = {
     height: 48,
     display: 'flex',
     alignItems: 'center',
+    justifyContent: 'space-between',
   },
   nav: {
     display: 'flex',
@@ -66,6 +95,12 @@ const styles: Record<string, React.CSSProperties> = {
     fontFamily: 'Inter, sans-serif',
     fontSize: 13,
     color: 'var(--color-text-secondary)',
+  },
+  headerLink: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: 13,
+    color: 'var(--color-text-secondary)',
+    textDecoration: 'none',
   },
   main: {
     maxWidth: 900,

--- a/src/web/src/context/AuthContext.tsx
+++ b/src/web/src/context/AuthContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import { getAuthUser, type AuthUser } from '../api/auth';
+import { isAdminUser } from '../api';
+import type { AdminUser } from '../types';
+
+interface AuthState {
+  user: AuthUser | null;
+  adminRecord: AdminUser | null;
+  isAdmin: boolean;
+  isPrimary: boolean;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthState>({
+  user: null,
+  adminRecord: null,
+  isAdmin: false,
+  isPrimary: false,
+  loading: true,
+});
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>({
+    user: null,
+    adminRecord: null,
+    isAdmin: false,
+    isPrimary: false,
+    loading: true,
+  });
+
+  useEffect(() => {
+    getAuthUser().then(async (user) => {
+      if (!user) {
+        setState({ user: null, adminRecord: null, isAdmin: false, isPrimary: false, loading: false });
+        return;
+      }
+      const adminRecord = await isAdminUser(user.username);
+      setState({
+        user,
+        adminRecord,
+        isAdmin: Boolean(adminRecord),
+        isPrimary: adminRecord?.isPrimary ?? false,
+        loading: false,
+      });
+    });
+  }, []);
+
+  return <AuthContext.Provider value={state}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthState {
+  return useContext(AuthContext);
+}

--- a/src/web/src/index.css
+++ b/src/web/src/index.css
@@ -167,6 +167,88 @@ textarea.input {
   color: #ffffff;
 }
 
+/* ── Admin shared ───────────────────────────────────────────────────────── */
+
+.admin-page-heading {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 22px;
+  color: var(--color-text-primary);
+  letter-spacing: -0.3px;
+}
+
+.admin-subheading {
+  font-family: 'Inter', sans-serif;
+  font-weight: 500;
+  font-size: 16px;
+  color: var(--color-text-primary);
+}
+
+.admin-divider {
+  height: 1px;
+  background: var(--color-border);
+  margin: 40px 0;
+  border: none;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.admin-table th {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  text-align: left;
+  padding: 0 12px 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-table td {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  color: var(--color-text-primary);
+  padding: 14px 12px;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-table td.muted {
+  color: var(--color-text-secondary);
+  font-size: 13px;
+}
+
+.admin-table td.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.badge {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 4px;
+  padding: 2px 8px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-muted);
+  color: var(--color-text-secondary);
+}
+
+.badge-accent {
+  color: var(--color-accent);
+}
+
+.badge-success {
+  color: var(--color-success);
+  background: #f0fdf4;
+  border-color: #bbf7d0;
+}
+
 /* ── Tag input ──────────────────────────────────────────────────────────── */
 
 .tag-input {

--- a/src/web/src/main.tsx
+++ b/src/web/src/main.tsx
@@ -2,10 +2,13 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import { router } from './router'
+import { AuthProvider } from './context/AuthContext'
 import './index.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <AuthProvider>
+      <RouterProvider router={router} />
+    </AuthProvider>
   </StrictMode>,
 )

--- a/src/web/src/pages/Unauthorized.tsx
+++ b/src/web/src/pages/Unauthorized.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom';
+
+export default function Unauthorized() {
+  return (
+    <div style={{ minHeight: '100vh', background: 'var(--color-background)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+      <div className="page-card" style={{ maxWidth: 440, width: '100%', display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <p style={{ fontFamily: 'Inter, sans-serif', fontSize: 11, fontWeight: 500, color: 'var(--color-text-secondary)', textTransform: 'uppercase', letterSpacing: '0.1em' }}>
+          Access restricted
+        </p>
+        <h1 className="admin-page-heading">You're not on the list.</h1>
+        <p style={{ fontFamily: 'Lora, serif', fontSize: 15, fontStyle: 'italic', color: 'var(--color-text-secondary)', lineHeight: 1.7 }}>
+          This site is managed by a private team. If you believe this is a mistake,
+          reach out to the site owner.
+        </p>
+        <Link to="/" className="btn btn-secondary" style={{ alignSelf: 'flex-start', marginTop: 8 }}>
+          ← Back to stories
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/pages/admin/Admins.tsx
+++ b/src/web/src/pages/admin/Admins.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import AdminLayout from '../../components/AdminLayout';
+import { getAdmins, addAdmin, removeAdmin, transferPrimary } from '../../api';
+import { useAuth } from '../../context/AuthContext';
+import type { AdminUser } from '../../types';
+
+export default function Admins() {
+  const { isPrimary } = useAuth();
+  const navigate = useNavigate();
+  const [admins, setAdmins] = useState<AdminUser[]>([]);
+  const [newUsername, setNewUsername] = useState('');
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isPrimary) { navigate('/admin'); return; }
+    getAdmins().then(setAdmins);
+  }, [isPrimary, navigate]);
+
+  async function handleAdd(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newUsername.trim()) return;
+    setAdding(true);
+    setError(null);
+    try {
+      const admin = await addAdmin(newUsername.trim());
+      setAdmins((prev) => [...prev, admin]);
+      setNewUsername('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add admin');
+    } finally {
+      setAdding(false);
+    }
+  }
+
+  async function handleRemove(id: string) {
+    if (!confirm('Remove this admin?')) return;
+    await removeAdmin(id);
+    setAdmins((prev) => prev.filter((a) => a.id !== id));
+  }
+
+  async function handleTransfer(id: string, username: string) {
+    if (!confirm(`Transfer primary to ${username}? You will lose primary access.`)) return;
+    await transferPrimary(id);
+    setAdmins((prev) => prev.map((a) => ({ ...a, isPrimary: a.id === id })));
+  }
+
+  return (
+    <AdminLayout breadcrumb="Manage admins">
+      <h1 className="admin-page-heading" style={{ marginBottom: 32 }}>Admins</h1>
+
+      <table className="admin-table">
+        <thead>
+          <tr>
+            <th>Username</th>
+            <th>Role</th>
+            <th>Added</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {admins.map((admin) => (
+            <tr key={admin.id}>
+              <td style={{ fontWeight: 500 }}>@{admin.username}</td>
+              <td>
+                <span className={`badge ${admin.isPrimary ? 'badge-accent' : ''}`}>
+                  {admin.isPrimary ? 'Primary' : 'Admin'}
+                </span>
+              </td>
+              <td className="muted">{new Date(admin.addedAt).toLocaleDateString()}</td>
+              <td className="actions">
+                {!admin.isPrimary && (
+                  <>
+                    <button className="btn btn-secondary" style={{ fontSize: 12, padding: '5px 10px' }} onClick={() => handleTransfer(admin.id, admin.username)}>
+                      Make primary
+                    </button>
+                    <button className="btn btn-danger" style={{ fontSize: 12, padding: '5px 10px' }} onClick={() => handleRemove(admin.id)}>
+                      Remove
+                    </button>
+                  </>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <hr className="admin-divider" />
+
+      <h2 className="admin-subheading" style={{ marginBottom: 20 }}>Add admin</h2>
+      <form onSubmit={handleAdd} style={{ display: 'flex', alignItems: 'flex-end', gap: 12 }}>
+        <div className="field" style={{ flex: 1, maxWidth: 300 }}>
+          <label htmlFor="newUsername">GitHub username</label>
+          <input
+            id="newUsername"
+            className="input"
+            value={newUsername}
+            onChange={(e) => setNewUsername(e.target.value)}
+            placeholder="e.g. octocat"
+          />
+        </div>
+        <button type="submit" className="btn btn-primary" disabled={adding || !newUsername.trim()}>
+          {adding ? 'Adding…' : 'Add admin'}
+        </button>
+      </form>
+      {error && <p style={{ fontFamily: 'Inter, sans-serif', fontSize: 13, color: 'var(--color-danger)', marginTop: 8 }}>{error}</p>}
+    </AdminLayout>
+  );
+}

--- a/src/web/src/pages/reader/Discovery.tsx
+++ b/src/web/src/pages/reader/Discovery.tsx
@@ -30,7 +30,7 @@ export default function Discovery() {
   return (
     <div style={styles.page}>
       <header style={styles.header}>
-        <h1 style={styles.siteTitle}>Story Time</h1>
+        <h1 style={styles.siteTitle}>Wistful.Me</h1>
         <p style={styles.siteTagline}>Stories worth staying up for.</p>
       </header>
 

--- a/src/web/src/router.tsx
+++ b/src/web/src/router.tsx
@@ -2,16 +2,20 @@ import { createBrowserRouter } from 'react-router-dom';
 import Discovery from './pages/reader/Discovery';
 import StoryTitle from './pages/reader/StoryTitle';
 import Chapter from './pages/reader/Chapter';
+import Unauthorized from './pages/Unauthorized';
 import AdminIndex from './pages/admin/Index';
 import StoryNew from './pages/admin/StoryNew';
 import StoryEdit from './pages/admin/StoryEdit';
 import ChapterNew from './pages/admin/ChapterNew';
+import Admins from './pages/admin/Admins';
 
 export const router = createBrowserRouter([
   { path: '/', element: <Discovery /> },
   { path: '/stories/:slug', element: <StoryTitle /> },
   { path: '/stories/:slug/chapters/:chapterId', element: <Chapter /> },
+  { path: '/unauthorized', element: <Unauthorized /> },
   { path: '/admin', element: <AdminIndex /> },
+  { path: '/admin/admins', element: <Admins /> },
   { path: '/admin/stories/new', element: <StoryNew /> },
   { path: '/admin/stories/:slug', element: <StoryEdit /> },
   { path: '/admin/stories/:slug/chapters/new', element: <ChapterNew /> },

--- a/src/web/src/types.ts
+++ b/src/web/src/types.ts
@@ -1,3 +1,10 @@
+export interface AdminUser {
+  id: string;
+  username: string;  // GitHub username
+  isPrimary: boolean;
+  addedAt: string;
+}
+
 export interface Chapter {
   id: string;
   storyId: string;


### PR DESCRIPTION
Rebrand — "Story Time" → Wistful.Me across all UI surfaces and package names
Admin whitelist — GitHub username-based auth gate; non-whitelisted authenticated users redirected to /unauthorized; AuthContext provides isAdmin / isPrimary to all admin pages
Role separation — primary admin can manage other admins (/admin/admins: add, remove, transfer primary); regular admins have story editing access only
Sign out — logout button in admin header; dev redirects home, prod hits /.auth/logout
Dev auth mock — GitHub username read from VITE_DEV_AUTH_USERNAME in .env.local (gitignored); .env.example added for self-hosters

[https://github.com/kelsi-jane/story-time/issues/8#issue-4369199454]