### PR TITLE
add concept of author to story

### DIFF
--- a/design/aesthethic.md
+++ b/design/aesthethic.md
@@ -106,6 +106,12 @@ The reader's primary devices are anticipated to be mobile (take the story with y
 
 For the admin-facing management surfaces, desktop-first is fine — but verify they don't break on mobile. Stack rather than overlap.
 
+## CSS implementation
+
+New components and pages must use existing CSS classes from `src/web/src/index.css` rather than defining a `const styles: Record<string, React.CSSProperties>` object. Classes available include `.btn`, `.btn-primary`, `.btn-secondary`, `.btn-danger`, `.field`, `.input`, `.page-card`, `.admin-table`, `.admin-page-heading`, `.admin-subheading`, `.admin-divider`, `.badge`, `.badge-accent`, `.badge-success`, `.prose`, and the markdown editor classes.
+
+Use inline styles only for truly one-off values (a specific `maxWidth`, `gap`, or `marginBottom`). If the same inline style appears in two or more components, extract it to a CSS class in `index.css` instead.
+
 ## When in doubt, do less
 
 If you're choosing between two visual options, choose the simpler one. If you're choosing between adding a feature and not adding it, lean toward not. If a component has more than five visible elements, ask whether two of them can be removed. If an animation would help, ask whether the same effect happens without animation.

--- a/design/architecture.md
+++ b/design/architecture.md
@@ -53,23 +53,39 @@ story-time/
 
 ## Auth Flow
 
-Azure Static Web Apps has native GitHub OAuth support. The admin route is protected via SWA's built-in role system — no custom auth code required.
+SWA route protection (`allowedRoles`) has been removed from `staticwebapp.config.json`. Auth is owned entirely by React via `AuthContext` and `AdminLayout`.
 
-1. Admin navigates to `/admin`
-2. SWA redirects to GitHub OAuth if not authenticated
-3. On success, SWA issues a session cookie scoped to the app
-4. Azure Functions receive the authenticated principal via request headers
+1. Unauthenticated user navigates to any `/admin/*` route
+2. `AdminLayout` detects `user === null` → redirects to `/.auth/login/github?post_login_redirect_uri=<current path>`
+3. GitHub OAuth completes → SWA redirects back to the original URL
+4. `AuthContext` fetches `/.auth/me`, reads `clientPrincipal.userDetails` (GitHub username)
+5. Username checked against admin whitelist (`isAdminUser`)
+6. Not whitelisted → `/unauthorized`; whitelisted → admin renders with role (`isAdmin`, `isPrimary`)
+
+**Why SWA protection was removed:** The built-in 401 override only accepts a static redirect URL, so post-login the user always landed on `/` instead of the page they came from. React ownership allows passing `window.location.pathname` as the return URL.
+
+**Local dev:** `getAuthUser()` returns the value of `VITE_DEV_AUTH_USERNAME` from `.env.local` instead of fetching `/.auth/me`. No real session exists locally.
+
+## Admin Whitelist
+
+GitHub username-based. Seeded from the `VITE_INITIAL_ADMIN_USERNAMES` environment variable (comma-separated; first entry is primary). Stored in `localStorage` in the mock API — will move to Azure Table Storage when the real API is wired.
+
+**Roles:**
+- `primary` — full access including `/admin/admins` (add/remove admins, transfer primary)
+- `admin` — story editing only; cannot access admin management
 
 ## Admin UI
 
-Protected by GitHub OAuth via SWA's built-in role system. Desktop-first; functional over polished.
+Desktop-first; functional over polished.
 
 | Route | Purpose |
 |---|---|
 | `/admin` | Story list — publish/unpublish, delete |
+| `/admin/admins` | Manage admin whitelist (primary only) |
 | `/admin/stories/new` | Create story + metadata (title, slug, tags, series) |
 | `/admin/stories/:slug` | Edit story metadata, manage + reorder chapters |
 | `/admin/stories/:slug/chapters/new` | Upload or write chapter Markdown |
+| `/admin/stories/:slug/chapters/:id/edit` | Edit existing chapter title and content |
 
 The admin UI is the only place where write operations are exposed. Reader-facing surfaces are read-only against the same API.
 

--- a/design/backlog.md
+++ b/design/backlog.md
@@ -44,3 +44,73 @@ Currently horizontal swipe navigates between chapters. In-chapter pagination wou
 
 ### Note on current scroll + swipe
 Current setup (vertical scroll to read, horizontal swipe to change chapter) has no conflict — `touch-action: pan-y` and `preventScrollOnSwipe` keep the gestures isolated. The conflict only arises if pagination is added.
+
+---
+
+## Series Badge on Discovery Cards
+
+**As a reader, I want to see at a glance that a story belongs to a series and what position it holds, so I know where to start.**
+
+### Scope
+- [ ] Badge on Discovery card: "Book N of [Series Name]"
+- [ ] Derive from `seriesSlug` + `seriesOrder` — data already exists, no model changes needed
+
+---
+
+## Publication Audit Log
+
+**As a platform operator, I want every publish and unpublish action to be permanently recorded, so that publication history is never lost and author attribution is protected.**
+
+### Why this matters
+
+The current `publishedAt: string | null` flag is mutable and creates two problems:
+
+1. **Author-lock bypass.** Author is locked once `publishedAt !== null`, but an admin can unpublish, change the author, and republish — circumventing the lock entirely.
+2. **No accountability.** There is no record of who published or unpublished a story, when, or why. This matters for moderation, disputes, and open-source deployments with larger author bases.
+
+### Design decisions
+
+**Publication state is an append-only event log, not a flag.** The current `publishedAt` field on `Story` is replaced by `publicationHistory: PublicationEvent[]`. `publishedAt` and `firstPublishedAt` become values derived from that history at read time.
+
+```
+PublicationEvent {
+  action:        'publish' | 'unpublish'
+  actorUsername: string      // who triggered it — may differ from the story's author
+  timestamp:     string
+  reason?:       string      // required for unpublish; optional for publish
+}
+```
+
+**Author lock rule changes.** Author is locked once `firstPublishedAt !== null` — i.e., once the story has ever been published — regardless of current publication state. Unpublish/republish cycles cannot change it.
+
+**Unpublish = temporary, Publish = weighty.** "Unpublish" is an author-initiated "under construction" action: the story is being revised before its next publication. It is not a deletion. Future UI should reflect this asymmetry — publishing is a normal action; unpublishing requires a confirmation gate and a required reason field.
+
+**Archive is a separate, heavier concept.** Archiving a story (permanent removal from reader-facing surfaces) has implications for associated reader data: likes, bookmarks, read history, comments, follows. Archive is out of scope until those reader features exist and the full impact is understood.
+
+### Scope (when built)
+
+- [ ] Replace `publishedAt: string | null` on `Story` with `publicationHistory: PublicationEvent[]`
+- [ ] Derive `publishedAt` (most recent `'publish'` event timestamp, or null) and `firstPublishedAt` (first `'publish'` event timestamp, or null) — expose as computed fields or derive at call sites
+- [ ] Update author-lock rule in `StoryEdit` to use `firstPublishedAt` instead of `publishedAt`
+- [ ] Update all publish/unpublish API calls to append an event rather than overwrite a field
+- [ ] Update admin UI publish/unpublish buttons to pass `actorUsername`
+- [ ] Unpublish gate: confirmation modal + required reason field (populated as `reason` on the event)
+- [ ] Admin story list: surface publication state derived from history (no visible change for readers)
+
+### Future / out of scope now
+
+- Moderator role: a non-author admin unpublishing someone else's story. The `actorUsername` field on `PublicationEvent` already supports this — the permission model is what's deferred.
+- Archive action and its implications for associated reader data.
+- Notification to author when a moderator (not the author) takes down their story.
+
+---
+
+## Image Upload (Admin)
+
+**As an admin, I want to upload cover and chapter images that are constrained to brand guidelines before being stored.**
+
+### Scope
+- [ ] Image upload UI in admin (story edit page)
+- [ ] Client-side aspect ratio and max dimension enforcement before write
+- [ ] Write to Azure Blob Storage (`images/{storySlug}/{imageId}.{ext}`)
+- [ ] Display uploaded images on StoryTitle and Chapter pages

--- a/design/deployment.md
+++ b/design/deployment.md
@@ -165,15 +165,31 @@ The workflow in `.github/workflows/azure-static-web-apps.yml` builds and deploys
 
 ---
 
+## Deployed Resources (current instance)
+
+| Resource | Value |
+|---|---|
+| Azure Static Web App name | `lively-ocean-0d34a8310` |
+| Hostname | `https://lively-ocean-0d34a8310.7.azurestaticapps.net` |
+| GitHub repository | `kelsi-jane/story-time` |
+| Workflow file | `.github/workflows/azure-static-web-apps-lively-ocean-0d34a8310.yml` |
+| Deploy token secret name | `AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_OCEAN_0D34A8310` |
+
+---
+
 ## Environment Variables Reference
 
-| Variable | Where set | Purpose |
-|---|---|---|
-| `GITHUB_CLIENT_ID` | SWA app settings | GitHub OAuth app client ID |
-| `GITHUB_CLIENT_SECRET` | SWA app settings | GitHub OAuth app client secret |
-| `AZURE_STORAGE_CONNECTION_STRING` | SWA app settings | Blob + Table Storage access |
-| `AzureWebJobsStorage` | `local.settings.json` | Functions local storage binding |
-| `AZURE_STATIC_WEB_APPS_API_TOKEN` | GitHub repository secret | SWA deployment token (set automatically) |
+`VITE_*` variables are build-time — Vite bakes them into the JS bundle during the GitHub Actions build. They are publicly readable in the bundle and must never contain secrets. See `design/security-concerns.md` for the full classification.
+
+| Variable | Type | Where set | Purpose |
+|---|---|---|---|
+| `VITE_DEV_AUTH_USERNAME` | Build-time | `.env.local` only | Mocks authenticated GitHub user in local dev |
+| `VITE_INITIAL_ADMIN_USERNAMES` | Build-time | SWA app settings + `.env.local` | Comma-separated GitHub usernames seeded as admins; first is primary |
+| `GITHUB_CLIENT_ID` | Build-time | SWA app settings | GitHub OAuth app client ID |
+| `GITHUB_CLIENT_SECRET` | Runtime, **secret** | GitHub Secrets → workflow `env:` | GitHub OAuth app client secret |
+| `AZURE_STORAGE_CONNECTION_STRING` | Runtime, **secret** | GitHub Secrets → workflow `env:` | Blob + Table Storage access |
+| `AzureWebJobsStorage` | Local only | `local.settings.json` | Functions local storage binding |
+| `AZURE_STATIC_WEB_APPS_API_TOKEN_*` | CI/CD | GitHub repository secret | SWA deployment token |
 
 ---
 
@@ -182,3 +198,4 @@ The workflow in `.github/workflows/azure-static-web-apps.yml` builds and deploys
 - `local.settings.json` is git-ignored — never commit it
 - `.azurite/` is git-ignored — local storage emulator data
 - The SWA free tier supports one deployment environment; pull request preview environments require Standard tier
+- `VITE_INITIAL_ADMIN_USERNAMES` must be set in Azure SWA app settings before deploying — without it the admin whitelist is empty and no one can log in

--- a/design/high-level.md
+++ b/design/high-level.md
@@ -61,3 +61,5 @@ Chapter
 - [Architecture](architecture.md)
 - [Backlog](backlog.md)
 - [Aesthetic](aesthethic.md)
+- [Security Concerns](security-concerns.md)
+- [Deployment](deployment.md)

--- a/design/security-concerns.md
+++ b/design/security-concerns.md
@@ -1,0 +1,35 @@
+# Security Concerns
+
+## No hardcoded personal information in source
+
+GitHub usernames, email addresses, and any personal identifiers must never appear in committed source files — even as temporary placeholders. They belong in environment variables.
+
+**Pattern in use:**
+- `VITE_DEV_AUTH_USERNAME` — mocks the authenticated GitHub user in local dev
+- `VITE_INITIAL_ADMIN_USERNAMES` — comma-separated list of seeded admin GitHub usernames (first is primary)
+
+Both are defined in `src/web/.env.local` (gitignored). `src/web/.env.example` documents the variable names without values for self-hosters.
+
+---
+
+## Environment variable classification
+
+Not all environment variables are equal. Misclassifying a secret as a build-time variable (or vice versa) creates either a security gap or a broken deployment.
+
+| Variable | Type | Where to set | Reason |
+|---|---|---|---|
+| `VITE_DEV_AUTH_USERNAME` | Build-time, non-secret | `.env.local` only | Dev-only mock, never deployed |
+| `VITE_INITIAL_ADMIN_USERNAMES` | Build-time, non-secret | Azure SWA app settings + `.env.local` | Baked into JS bundle at build time; usernames are not secrets |
+| `GITHUB_CLIENT_ID` | Build-time, semi-public | Azure SWA app settings | Appears in OAuth redirect URLs anyway |
+| `GITHUB_CLIENT_SECRET` | Runtime, **secret** | GitHub Secrets (injected via workflow `env:`) | Must be masked in logs; never baked into bundle |
+| `AZURE_STORAGE_CONNECTION_STRING` | Runtime, **secret** | GitHub Secrets (injected via workflow `env:`) | Contains credentials; must be masked |
+
+**Rule:** `VITE_*` variables are embedded in the JavaScript bundle at build time and are publicly readable. Never put secrets in `VITE_*` variables. Secrets belong in GitHub Secrets, where they are automatically masked in Actions logs.
+
+---
+
+## Admin whitelist
+
+The admin whitelist currently lives in `localStorage` (mock API). This is a temporary measure — it means whitelist additions only persist per-device and per-browser. When the real API is wired up, the whitelist moves to Azure Table Storage and becomes the authoritative source.
+
+The mock API localStorage keys are: `st-mock-stories`, `st-mock-content`, `st-mock-admins`.

--- a/src/web/src/api/index.ts
+++ b/src/web/src/api/index.ts
@@ -1,4 +1,4 @@
-import type { Story, Chapter, AdminUser } from '../types';
+import type { Story, Chapter, AdminUser, Author } from '../types';
 
 const INITIAL_STORIES: Story[] = [
   {
@@ -93,6 +93,48 @@ function saveAdmins(a: AdminUser[]): void {
 
 let admins: AdminUser[] = loadAdmins();
 
+// ── Author profiles ──────────────────────────────────────────────────────────
+
+const AUTHORS_KEY = 'st-mock-authors';
+
+function loadAuthors(): Author[] {
+  try {
+    const raw = localStorage.getItem(AUTHORS_KEY);
+    if (raw) return JSON.parse(raw) as Author[];
+  } catch {}
+  return INITIAL_ADMINS.map((admin) => ({
+    githubUsername: admin.username,
+    fullName: '',
+    penName: admin.username,
+  }));
+}
+
+function saveAuthors(a: Author[]): void {
+  localStorage.setItem(AUTHORS_KEY, JSON.stringify(a));
+}
+
+let authors: Author[] = loadAuthors();
+
+export async function getAuthors(): Promise<Author[]> {
+  const adminUsernames = new Set(admins.map((a) => a.username.toLowerCase()));
+  return authors.filter((a) => adminUsernames.has(a.githubUsername.toLowerCase()));
+}
+
+export async function getAuthor(username: string): Promise<Author | null> {
+  return authors.find((a) => a.githubUsername.toLowerCase() === username.toLowerCase()) ?? null;
+}
+
+export async function updateAuthor(username: string, data: { fullName: string; penName: string }): Promise<Author> {
+  const penName = data.penName.trim() || data.fullName.trim();
+  authors = authors.map((a) =>
+    a.githubUsername.toLowerCase() === username.toLowerCase()
+      ? { ...a, fullName: data.fullName.trim(), penName }
+      : a,
+  );
+  saveAuthors(authors);
+  return authors.find((a) => a.githubUsername.toLowerCase() === username.toLowerCase())!;
+}
+
 export async function getAdmins(): Promise<AdminUser[]> {
   return admins;
 }
@@ -109,6 +151,10 @@ export async function addAdmin(username: string): Promise<AdminUser> {
   const admin: AdminUser = { id: crypto.randomUUID(), username, isPrimary: false, addedAt: new Date().toISOString() };
   admins = [...admins, admin];
   saveAdmins(admins);
+  if (!authors.find((a) => a.githubUsername.toLowerCase() === username.toLowerCase())) {
+    authors = [...authors, { githubUsername: username, fullName: '', penName: username }];
+    saveAuthors(authors);
+  }
   return admin;
 }
 
@@ -118,6 +164,8 @@ export async function removeAdmin(id: string): Promise<void> {
   if (target.isPrimary) throw new Error('Cannot remove the primary admin');
   admins = admins.filter((a) => a.id !== id);
   saveAdmins(admins);
+  authors = authors.filter((a) => a.githubUsername.toLowerCase() !== target.username.toLowerCase());
+  saveAuthors(authors);
 }
 
 export async function transferPrimary(toId: string): Promise<void> {
@@ -125,6 +173,15 @@ export async function transferPrimary(toId: string): Promise<void> {
   if (!target) throw new Error('Admin not found');
   admins = admins.map((a) => ({ ...a, isPrimary: a.id === toId }));
   saveAdmins(admins);
+}
+
+// ── Migration ────────────────────────────────────────────────────────────────
+
+export async function migrateStoryAuthors(defaultUsername: string): Promise<Story[]> {
+  if (!stories.some((s) => !s.authorUsername)) return stories;
+  stories = stories.map((s) => (s.authorUsername ? s : { ...s, authorUsername: defaultUsername }));
+  saveStories(stories);
+  return stories;
 }
 
 // ── Read ────────────────────────────────────────────────────────────────────

--- a/src/web/src/index.css
+++ b/src/web/src/index.css
@@ -307,6 +307,14 @@ textarea.input {
   color: var(--color-border);
 }
 
+/* ── Reader story byline ────────────────────────────────────────────────── */
+
+.story-author {
+  font-family: 'Inter', sans-serif;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
 /* ── Markdown editor ────────────────────────────────────────────────────── */
 
 .mde {

--- a/src/web/src/pages/admin/Admins.tsx
+++ b/src/web/src/pages/admin/Admins.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import AdminLayout from '../../components/AdminLayout';
-import { getAdmins, addAdmin, removeAdmin, transferPrimary } from '../../api';
+import { getAdmins, addAdmin, removeAdmin, transferPrimary, getAuthors, updateAuthor } from '../../api';
 import { useAuth } from '../../context/AuthContext';
-import type { AdminUser } from '../../types';
+import type { AdminUser, Author } from '../../types';
 
 export default function Admins() {
   const { isPrimary } = useAuth();
@@ -13,9 +13,18 @@ export default function Admins() {
   const [adding, setAdding] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [authors, setAuthors] = useState<Author[]>([]);
+  const [editingUsername, setEditingUsername] = useState<string | null>(null);
+  const [editForm, setEditForm] = useState({ fullName: '', penName: '' });
+  const [editSaving, setEditSaving] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
   useEffect(() => {
     if (!isPrimary) { navigate('/admin'); return; }
-    getAdmins().then(setAdmins);
+    Promise.all([getAdmins(), getAuthors()]).then(([a, auth]) => {
+      setAdmins(a);
+      setAuthors(auth);
+    });
   }, [isPrimary, navigate]);
 
   async function handleAdd(e: React.FormEvent) {
@@ -26,6 +35,7 @@ export default function Admins() {
     try {
       const admin = await addAdmin(newUsername.trim());
       setAdmins((prev) => [...prev, admin]);
+      setAuthors((prev) => [...prev, { githubUsername: newUsername.trim(), fullName: '', penName: newUsername.trim() }]);
       setNewUsername('');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add admin');
@@ -36,14 +46,47 @@ export default function Admins() {
 
   async function handleRemove(id: string) {
     if (!confirm('Remove this admin?')) return;
+    const target = admins.find((a) => a.id === id);
     await removeAdmin(id);
     setAdmins((prev) => prev.filter((a) => a.id !== id));
+    if (target) {
+      setAuthors((prev) => prev.filter((a) => a.githubUsername.toLowerCase() !== target.username.toLowerCase()));
+    }
   }
 
   async function handleTransfer(id: string, username: string) {
     if (!confirm(`Transfer primary to ${username}? You will lose primary access.`)) return;
     await transferPrimary(id);
     setAdmins((prev) => prev.map((a) => ({ ...a, isPrimary: a.id === id })));
+  }
+
+  function startEdit(author: Author) {
+    setEditingUsername(author.githubUsername);
+    setEditForm({ fullName: author.fullName, penName: author.penName });
+    setEditError(null);
+  }
+
+  function cancelEdit() {
+    setEditingUsername(null);
+    setEditError(null);
+  }
+
+  async function handleSaveAuthor(username: string) {
+    if (!editForm.fullName.trim()) {
+      setEditError('Full name is required.');
+      return;
+    }
+    setEditSaving(true);
+    setEditError(null);
+    try {
+      const updated = await updateAuthor(username, editForm);
+      setAuthors((prev) => prev.map((a) => (a.githubUsername === username ? updated : a)));
+      setEditingUsername(null);
+    } catch (err) {
+      setEditError(err instanceof Error ? err.message : 'Failed to save');
+    } finally {
+      setEditSaving(false);
+    }
   }
 
   return (
@@ -105,6 +148,80 @@ export default function Admins() {
         </button>
       </form>
       {error && <p style={{ fontFamily: 'Inter, sans-serif', fontSize: 13, color: 'var(--color-danger)', marginTop: 8 }}>{error}</p>}
+
+      <hr className="admin-divider" />
+
+      <h2 className="admin-subheading" style={{ marginBottom: 4 }}>Author profiles</h2>
+      <p style={{ fontSize: 13, color: 'var(--color-text-secondary)', marginBottom: 20 }}>
+        Used as the byline on published stories. Pen name defaults to full name if left blank.
+      </p>
+
+      <table className="admin-table">
+        <thead>
+          <tr>
+            <th>GitHub</th>
+            <th>Full name</th>
+            <th>Pen name</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {authors.map((author) => (
+            <tr key={author.githubUsername}>
+              {editingUsername === author.githubUsername ? (
+                <>
+                  <td className="muted">@{author.githubUsername}</td>
+                  <td>
+                    <input
+                      className="input"
+                      value={editForm.fullName}
+                      onChange={(e) => setEditForm((prev) => ({ ...prev, fullName: e.target.value }))}
+                      placeholder="Full name"
+                      style={{ minWidth: 160 }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      className="input"
+                      value={editForm.penName}
+                      onChange={(e) => setEditForm((prev) => ({ ...prev, penName: e.target.value }))}
+                      placeholder={editForm.fullName || author.githubUsername}
+                      style={{ minWidth: 160 }}
+                    />
+                  </td>
+                  <td className="actions">
+                    <button
+                      className="btn btn-primary"
+                      style={{ fontSize: 12, padding: '5px 10px' }}
+                      disabled={editSaving}
+                      onClick={() => handleSaveAuthor(author.githubUsername)}
+                    >
+                      {editSaving ? 'Saving…' : 'Save'}
+                    </button>
+                    <button className="btn btn-secondary" style={{ fontSize: 12, padding: '5px 10px' }} onClick={cancelEdit}>
+                      Cancel
+                    </button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td className="muted">@{author.githubUsername}</td>
+                  <td>
+                    {author.fullName || <span style={{ color: 'var(--color-text-secondary)', fontStyle: 'italic' }}>Not set</span>}
+                  </td>
+                  <td>{author.penName}</td>
+                  <td className="actions">
+                    <button className="btn btn-secondary" style={{ fontSize: 12, padding: '5px 10px' }} onClick={() => startEdit(author)}>
+                      Edit
+                    </button>
+                  </td>
+                </>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {editError && <p style={{ fontSize: 13, color: 'var(--color-danger)', marginTop: 8 }}>{editError}</p>}
     </AdminLayout>
   );
 }

--- a/src/web/src/pages/admin/Index.tsx
+++ b/src/web/src/pages/admin/Index.tsx
@@ -1,16 +1,21 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import AdminLayout from '../../components/AdminLayout';
-import { getStories, updateStory, deleteStory } from '../../api';
+import { migrateStoryAuthors, updateStory, deleteStory } from '../../api';
+import { useAuth } from '../../context/AuthContext';
 import type { Story } from '../../types';
 
 export default function AdminIndex() {
+  const { user } = useAuth();
   const [stories, setStories] = useState<Story[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    getStories().then(setStories).finally(() => setLoading(false));
-  }, []);
+    if (!user) return;
+    migrateStoryAuthors(user.username)
+      .then(setStories)
+      .finally(() => setLoading(false));
+  }, [user?.username]);
 
   async function togglePublish(story: Story) {
     const updated = await updateStory(story.slug, {
@@ -27,8 +32,8 @@ export default function AdminIndex() {
 
   return (
     <AdminLayout>
-      <div style={styles.titleRow}>
-        <h1 style={styles.heading}>Stories</h1>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 32 }}>
+        <h1 className="admin-page-heading">Stories</h1>
         <Link to="/admin/stories/new" className="btn btn-primary">+ New story</Link>
       </div>
 
@@ -51,6 +56,7 @@ export default function AdminIndex() {
                 <td style={styles.td}>
                   <Link to={`/admin/stories/${story.slug}`} style={styles.storyLink}>
                     {story.title}
+                    {story.subtitle && <span style={styles.storySubtitle}>: {story.subtitle}</span>}
                   </Link>
                 </td>
                 <td style={styles.td}>
@@ -84,8 +90,6 @@ export default function AdminIndex() {
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  titleRow: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 32 },
-  heading: { fontFamily: 'Inter, sans-serif', fontWeight: 500, fontSize: 22, color: 'var(--color-text-primary)' },
   table: { width: '100%', borderCollapse: 'collapse' },
   th: {
     fontFamily: 'Inter, sans-serif', fontSize: 12, fontWeight: 500,
@@ -96,6 +100,7 @@ const styles: Record<string, React.CSSProperties> = {
   td: { fontFamily: 'Inter, sans-serif', fontSize: 14, color: 'var(--color-text-primary)', padding: '14px 12px', verticalAlign: 'middle' },
   numeric: { color: 'var(--color-text-secondary)' },
   storyLink: { color: 'var(--color-text-primary)', fontWeight: 500, textDecoration: 'none' },
+  storySubtitle: { fontWeight: 400, color: 'var(--color-text-secondary)', fontStyle: 'italic' },
   published: { fontSize: 12, fontWeight: 500, color: 'var(--color-success)', background: '#f0fdf4', border: '1px solid #bbf7d0', borderRadius: 4, padding: '2px 8px' },
   draft: { fontSize: 12, fontWeight: 500, color: 'var(--color-text-secondary)', background: 'var(--color-surface-muted)', border: '1px solid var(--color-border)', borderRadius: 4, padding: '2px 8px' },
   tagRow: { display: 'flex', flexWrap: 'wrap', gap: 4 },

--- a/src/web/src/pages/admin/StoryEdit.tsx
+++ b/src/web/src/pages/admin/StoryEdit.tsx
@@ -5,8 +5,9 @@ import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } 
 import { CSS } from '@dnd-kit/utilities';
 import AdminLayout from '../../components/AdminLayout';
 import TagInput from '../../components/TagInput';
-import { getStory, updateStory, deleteStory, deleteChapter, reorderChapters } from '../../api';
-import type { Story, Chapter } from '../../types';
+import { getStory, updateStory, deleteStory, deleteChapter, reorderChapters, getAuthors } from '../../api';
+import { useAuth } from '../../context/AuthContext';
+import type { Story, Chapter, Author } from '../../types';
 
 function SortableChapterRow({ chapter, storySlug, onDeleted }: {
   chapter: Chapter;
@@ -25,43 +26,48 @@ function SortableChapterRow({ chapter, storySlug, onDeleted }: {
     <div
       ref={setNodeRef}
       style={{
-        ...rowStyles.row,
+        display: 'flex', alignItems: 'center', gap: 12, padding: '10px 12px',
+        background: 'var(--color-surface)', border: '1px solid var(--color-border)',
+        borderRadius: 4, marginBottom: 4,
         transform: CSS.Transform.toString(transform),
         transition,
         opacity: isDragging ? 0.4 : 1,
       }}
     >
-      <span {...attributes} {...listeners} style={rowStyles.handle} title="Drag to reorder">⠿</span>
-      <span style={rowStyles.order}>{chapter.order}</span>
-      <span style={rowStyles.title}>{chapter.title}</span>
-      <Link to={`/admin/stories/${storySlug}/chapters/${chapter.id}/edit`} className="btn btn-secondary" style={rowStyles.editBtn}>Edit</Link>
-      <button className="btn btn-danger" style={rowStyles.deleteBtn} onClick={handleDelete}>Delete</button>
+      <span {...attributes} {...listeners} style={{ cursor: 'grab', color: 'var(--color-border)', fontSize: 18, lineHeight: 1, userSelect: 'none' }} title="Drag to reorder">⠿</span>
+      <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 12, color: 'var(--color-text-secondary)', minWidth: 16, textAlign: 'right' }}>{chapter.order}</span>
+      <span style={{ fontFamily: 'Inter, sans-serif', fontSize: 14, color: 'var(--color-text-primary)', flex: 1 }}>{chapter.title}</span>
+      <Link to={`/admin/stories/${storySlug}/chapters/${chapter.id}/edit`} className="btn btn-secondary" style={{ fontSize: 12, padding: '4px 10px' }}>Edit</Link>
+      <button className="btn btn-danger" style={{ fontSize: 12, padding: '4px 10px' }} onClick={handleDelete}>Delete</button>
     </div>
   );
 }
 
-const rowStyles: Record<string, React.CSSProperties> = {
-  row: { display: 'flex', alignItems: 'center', gap: 12, padding: '10px 12px', background: 'var(--color-surface)', border: '1px solid var(--color-border)', borderRadius: 4, marginBottom: 4 },
-  handle: { cursor: 'grab', color: 'var(--color-border)', fontSize: 18, lineHeight: 1, userSelect: 'none' },
-  order: { fontFamily: 'Inter, sans-serif', fontSize: 12, color: 'var(--color-text-secondary)', minWidth: 16, textAlign: 'right' },
-  title: { fontFamily: 'Inter, sans-serif', fontSize: 14, color: 'var(--color-text-primary)', flex: 1 },
-  editBtn: { fontSize: 12, padding: '4px 10px' },
-  deleteBtn: { fontSize: 12, padding: '4px 10px' },
-};
-
 export default function StoryEdit() {
   const { slug } = useParams<{ slug: string }>();
   const navigate = useNavigate();
+  const { user } = useAuth();
   const [story, setStory] = useState<Story | null>(null);
   const [chapters, setChapters] = useState<Chapter[]>([]);
+  const [authors, setAuthors] = useState<Author[]>([]);
   const [saving, setSaving] = useState(false);
-  const [form, setForm] = useState({ title: '', subtitle: '', description: '', tags: [] as string[], seriesSlug: '', seriesOrder: '' });
+  const [consentChecked, setConsentChecked] = useState(false);
+  const [form, setForm] = useState({
+    title: '',
+    subtitle: '',
+    description: '',
+    tags: [] as string[],
+    seriesSlug: '',
+    seriesOrder: '',
+    authorUsername: '',
+  });
 
   useEffect(() => {
     if (!slug) return;
-    getStory(slug).then((s) => {
+    Promise.all([getStory(slug), getAuthors()]).then(([s, a]) => {
       if (!s) return;
       setStory(s);
+      setAuthors(a);
       setChapters(s.chapters.slice().sort((a, b) => a.order - b.order));
       setForm({
         title: s.title,
@@ -70,17 +76,20 @@ export default function StoryEdit() {
         tags: s.tags,
         seriesSlug: s.seriesSlug ?? '',
         seriesOrder: s.seriesOrder?.toString() ?? '',
+        authorUsername: s.authorUsername ?? user?.username ?? '',
       });
     });
   }, [slug]);
 
   function set(field: string, value: string | string[]) {
+    if (field === 'authorUsername') setConsentChecked(false);
     setForm((prev) => ({ ...prev, [field]: value }));
   }
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault();
-    if (!slug) return;
+    if (!slug || !story) return;
+    if (form.authorUsername !== user?.username && !consentChecked) return;
     setSaving(true);
     try {
       const updated = await updateStory(slug, {
@@ -90,6 +99,7 @@ export default function StoryEdit() {
         tags: form.tags,
         seriesSlug: form.seriesSlug.trim() || undefined,
         seriesOrder: form.seriesOrder ? parseInt(form.seriesOrder) : undefined,
+        ...(story.publishedAt === null ? { authorUsername: form.authorUsername } : {}),
       });
       setStory(updated);
     } finally {
@@ -115,25 +125,29 @@ export default function StoryEdit() {
 
   if (!story) return null;
 
+  const isPublished = story.publishedAt !== null;
+  const selectedAuthor = authors.find((a) => a.githubUsername === form.authorUsername);
+  const needsConsent = !!form.authorUsername && form.authorUsername !== user?.username;
+
   return (
     <AdminLayout breadcrumb={story.title}>
-      <form onSubmit={handleSave} style={styles.form}>
-        <div style={styles.titleRow}>
-          <h1 style={styles.heading}>{story.title}</h1>
-          <div style={styles.titleActions}>
+      <form onSubmit={handleSave}>
+        <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, marginBottom: 32 }}>
+          <h1 className="admin-page-heading">{story.title}</h1>
+          <div style={{ display: 'flex', gap: 10, flexShrink: 0 }}>
             <button type="button" className="btn btn-danger" onClick={handleDelete}>Delete story</button>
-            <button type="submit" className="btn btn-primary" disabled={saving}>{saving ? 'Saving…' : 'Save changes'}</button>
+            <button type="submit" className="btn btn-primary" disabled={saving || (needsConsent && !consentChecked)}>{saving ? 'Saving…' : 'Save changes'}</button>
           </div>
         </div>
 
-        <div style={styles.fields}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 20, maxWidth: 600 }}>
           <div className="field">
             <label htmlFor="title">Title</label>
             <input id="title" className="input" value={form.title} onChange={(e) => set('title', e.target.value)} required />
           </div>
 
           <div className="field">
-            <label htmlFor="subtitle">Subtitle <span style={styles.optional}>(optional)</span></label>
+            <label htmlFor="subtitle">Subtitle <span style={{ fontWeight: 400, color: 'var(--color-text-secondary)' }}>(optional)</span></label>
             <input id="subtitle" className="input" value={form.subtitle} onChange={(e) => set('subtitle', e.target.value)} placeholder="e.g. Wedding Bells" />
           </div>
 
@@ -147,28 +161,69 @@ export default function StoryEdit() {
             <TagInput value={form.tags} onChange={(tags) => set('tags', tags)} />
           </div>
 
-          <div style={styles.row}>
+          <div className="field">
+            <label htmlFor="author">Author</label>
+            {isPublished ? (
+              <p style={{ fontSize: 14, color: 'var(--color-text-secondary)', padding: '8px 0', fontStyle: 'italic' }}>
+                {selectedAuthor?.penName || form.authorUsername}
+                <span style={{ fontSize: 12, marginLeft: 8 }}>(locked after publish)</span>
+              </p>
+            ) : authors.length <= 1 ? (
+              <p style={{ fontSize: 14, color: 'var(--color-text-primary)', padding: '8px 0' }}>
+                {selectedAuthor ? (selectedAuthor.penName || selectedAuthor.githubUsername) : (user?.username ?? '—')}
+              </p>
+            ) : (
+              <select
+                id="author"
+                className="input"
+                value={form.authorUsername}
+                onChange={(e) => set('authorUsername', e.target.value)}
+              >
+                {authors.map((a) => (
+                  <option key={a.githubUsername} value={a.githubUsername}>
+                    {a.penName || a.githubUsername}{a.githubUsername === user?.username ? ' (you)' : ''}
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+
+          {!isPublished && needsConsent && (
+            <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, fontSize: 13, color: 'var(--color-text-primary)', cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={consentChecked}
+                onChange={(e) => setConsentChecked(e.target.checked)}
+                style={{ marginTop: 2, flexShrink: 0 }}
+              />
+              I have permission to publish on behalf of {selectedAuthor?.penName || form.authorUsername}.
+            </label>
+          )}
+
+          <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
             <div className="field" style={{ flex: 1 }}>
-              <label htmlFor="seriesSlug">Series slug <span style={styles.optional}>(optional)</span></label>
+              <label htmlFor="seriesSlug">Series slug <span style={{ fontWeight: 400, color: 'var(--color-text-secondary)' }}>(optional)</span></label>
               <input id="seriesSlug" className="input" value={form.seriesSlug} onChange={(e) => set('seriesSlug', e.target.value)} />
             </div>
             <div className="field" style={{ width: 100 }}>
-              <label htmlFor="seriesOrder">Order <span style={styles.optional}>(optional)</span></label>
+              <label htmlFor="seriesOrder">Order <span style={{ fontWeight: 400, color: 'var(--color-text-secondary)' }}>(optional)</span></label>
               <input id="seriesOrder" className="input" type="number" min={1} value={form.seriesOrder} onChange={(e) => set('seriesOrder', e.target.value)} />
             </div>
           </div>
         </div>
       </form>
 
-      <div style={styles.divider} />
+      <hr className="admin-divider" />
 
-      <div style={styles.chaptersHeader}>
-        <h2 style={styles.subheading}>Chapters</h2>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+        <h2 className="admin-subheading">Chapters</h2>
         <Link to={`/admin/stories/${slug}/chapters/new`} className="btn btn-secondary">+ Add chapter</Link>
       </div>
 
       {chapters.length === 0 ? (
-        <p style={styles.muted}>No chapters yet. <Link to={`/admin/stories/${slug}/chapters/new`}>Add one.</Link></p>
+        <p style={{ fontFamily: 'Inter, sans-serif', fontSize: 14, color: 'var(--color-text-secondary)' }}>
+          No chapters yet. <Link to={`/admin/stories/${slug}/chapters/new`}>Add one.</Link>
+        </p>
       ) : (
         <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext items={chapters.map((c) => c.id)} strategy={verticalListSortingStrategy}>
@@ -186,17 +241,3 @@ export default function StoryEdit() {
     </AdminLayout>
   );
 }
-
-const styles: Record<string, React.CSSProperties> = {
-  form: {},
-  titleRow: { display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', gap: 16, marginBottom: 32 },
-  heading: { fontFamily: 'Inter, sans-serif', fontWeight: 500, fontSize: 22, color: 'var(--color-text-primary)' },
-  titleActions: { display: 'flex', gap: 10, flexShrink: 0 },
-  fields: { display: 'flex', flexDirection: 'column', gap: 20, maxWidth: 600 },
-  row: { display: 'flex', gap: 16, alignItems: 'flex-start' },
-  optional: { fontWeight: 400, color: 'var(--color-text-secondary)' },
-  divider: { height: 1, background: 'var(--color-border)', margin: '40px 0' },
-  chaptersHeader: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 },
-  subheading: { fontFamily: 'Inter, sans-serif', fontWeight: 500, fontSize: 16, color: 'var(--color-text-primary)' },
-  muted: { fontFamily: 'Inter, sans-serif', fontSize: 14, color: 'var(--color-text-secondary)' },
-};

--- a/src/web/src/pages/admin/StoryNew.tsx
+++ b/src/web/src/pages/admin/StoryNew.tsx
@@ -1,8 +1,10 @@
-import { useState, type ChangeEvent } from 'react';
+import { useState, useEffect, type ChangeEvent } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import AdminLayout from '../../components/AdminLayout';
 import TagInput from '../../components/TagInput';
-import { createStory } from '../../api';
+import { createStory, getAuthors } from '../../api';
+import { useAuth } from '../../context/AuthContext';
+import type { Author } from '../../types';
 
 function toSlug(title: string): string {
   return title.toLowerCase().replace(/[^a-z0-9\s-]/g, '').trim().replace(/\s+/g, '-');
@@ -10,8 +12,11 @@ function toSlug(title: string): string {
 
 export default function StoryNew() {
   const navigate = useNavigate();
+  const { user } = useAuth();
+  const [authors, setAuthors] = useState<Author[]>([]);
   const [saving, setSaving] = useState(false);
   const [slugEdited, setSlugEdited] = useState(false);
+  const [consentChecked, setConsentChecked] = useState(false);
   const [form, setForm] = useState({
     title: '',
     slug: '',
@@ -20,9 +25,15 @@ export default function StoryNew() {
     tags: [] as string[],
     seriesSlug: '',
     seriesOrder: '',
+    authorUsername: user?.username ?? '',
   });
 
+  useEffect(() => {
+    getAuthors().then(setAuthors);
+  }, []);
+
   function set(field: string, value: string | string[]) {
+    if (field === 'authorUsername') setConsentChecked(false);
     setForm((prev) => ({ ...prev, [field]: value }));
   }
 
@@ -37,7 +48,8 @@ export default function StoryNew() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!form.title.trim() || !form.slug.trim()) return;
+    if (!form.title.trim() || !form.slug.trim() || !form.authorUsername) return;
+    if (form.authorUsername !== user?.username && !consentChecked) return;
     setSaving(true);
     try {
       await createStory({
@@ -49,6 +61,7 @@ export default function StoryNew() {
         seriesSlug: form.seriesSlug.trim() || undefined,
         seriesOrder: form.seriesOrder ? parseInt(form.seriesOrder) : undefined,
         publishedAt: null,
+        authorUsername: form.authorUsername,
       });
       navigate(`/admin/stories/${form.slug.trim()}`);
     } finally {
@@ -56,11 +69,15 @@ export default function StoryNew() {
     }
   }
 
+  const selectedAuthor = authors.find((a) => a.githubUsername === form.authorUsername);
+  const needsConsent = !!form.authorUsername && form.authorUsername !== user?.username;
+  const canSubmit = !!form.authorUsername && (!needsConsent || consentChecked);
+
   return (
     <AdminLayout breadcrumb="New story">
-      <h1 style={styles.heading}>New story</h1>
+      <h1 className="admin-page-heading" style={{ marginBottom: 32 }}>New story</h1>
 
-      <form onSubmit={handleSubmit} style={styles.form}>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 600 }}>
         <div className="field">
           <label htmlFor="title">Title</label>
           <input id="title" className="input" value={form.title} onChange={handleTitleChange} required />
@@ -77,7 +94,7 @@ export default function StoryNew() {
         </div>
 
         <div className="field">
-          <label htmlFor="subtitle">Subtitle <span style={styles.optional}>(optional)</span></label>
+          <label htmlFor="subtitle">Subtitle <span style={{ fontWeight: 400, color: 'var(--color-text-secondary)' }}>(optional)</span></label>
           <input id="subtitle" className="input" value={form.subtitle} onChange={(e) => set('subtitle', e.target.value)} placeholder="e.g. Wedding Bells" />
           <span className="hint">Appears after the title, separated by a colon</span>
         </div>
@@ -88,24 +105,58 @@ export default function StoryNew() {
         </div>
 
         <div className="field">
+          <label htmlFor="author">Author</label>
+          {authors.length <= 1 ? (
+            <p style={{ fontSize: 14, color: 'var(--color-text-primary)', padding: '8px 0' }}>
+              {selectedAuthor ? (selectedAuthor.penName || selectedAuthor.githubUsername) : (user?.username ?? '—')}
+            </p>
+          ) : (
+            <select
+              id="author"
+              className="input"
+              value={form.authorUsername}
+              onChange={(e) => set('authorUsername', e.target.value)}
+            >
+              {authors.map((a) => (
+                <option key={a.githubUsername} value={a.githubUsername}>
+                  {a.penName || a.githubUsername}{a.githubUsername === user?.username ? ' (you)' : ''}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {needsConsent && (
+          <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, fontSize: 13, color: 'var(--color-text-primary)', cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={consentChecked}
+              onChange={(e) => setConsentChecked(e.target.checked)}
+              style={{ marginTop: 2, flexShrink: 0 }}
+            />
+            I have permission to publish on behalf of {selectedAuthor?.penName || form.authorUsername}.
+          </label>
+        )}
+
+        <div className="field">
           <label>Tags</label>
           <TagInput value={form.tags} onChange={(tags) => set('tags', tags)} />
         </div>
 
-        <div style={styles.row}>
+        <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
           <div className="field" style={{ flex: 1 }}>
-            <label htmlFor="seriesSlug">Series slug <span style={styles.optional}>(optional)</span></label>
+            <label htmlFor="seriesSlug">Series slug <span style={{ fontWeight: 400, color: 'var(--color-text-secondary)' }}>(optional)</span></label>
             <input id="seriesSlug" className="input" value={form.seriesSlug} onChange={(e) => set('seriesSlug', e.target.value)} placeholder="e.g. crimson-chronicles" />
           </div>
           <div className="field" style={{ width: 100 }}>
-            <label htmlFor="seriesOrder">Order <span style={styles.optional}>(optional)</span></label>
+            <label htmlFor="seriesOrder">Order <span style={{ fontWeight: 400, color: 'var(--color-text-secondary)' }}>(optional)</span></label>
             <input id="seriesOrder" className="input" type="number" min={1} value={form.seriesOrder} onChange={(e) => set('seriesOrder', e.target.value)} />
           </div>
         </div>
 
-        <div style={styles.actions}>
+        <div style={{ display: 'flex', gap: 12, paddingTop: 8 }}>
           <Link to="/admin" className="btn btn-secondary">Cancel</Link>
-          <button type="submit" className="btn btn-primary" disabled={saving}>
+          <button type="submit" className="btn btn-primary" disabled={saving || !canSubmit}>
             {saving ? 'Creating…' : 'Create story'}
           </button>
         </div>
@@ -113,11 +164,3 @@ export default function StoryNew() {
     </AdminLayout>
   );
 }
-
-const styles: Record<string, React.CSSProperties> = {
-  heading: { fontFamily: 'Inter, sans-serif', fontWeight: 500, fontSize: 22, color: 'var(--color-text-primary)', marginBottom: 32 },
-  form: { display: 'flex', flexDirection: 'column', gap: 24, maxWidth: 600 },
-  row: { display: 'flex', gap: 16, alignItems: 'flex-start' },
-  optional: { fontWeight: 400, color: 'var(--color-text-secondary)' },
-  actions: { display: 'flex', gap: 12, paddingTop: 8 },
-};

--- a/src/web/src/pages/reader/Discovery.tsx
+++ b/src/web/src/pages/reader/Discovery.tsx
@@ -1,16 +1,20 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getStories } from '../../api';
-import type { Story } from '../../types';
+import { getStories, getAuthors } from '../../api';
+import type { Story, Author } from '../../types';
 
 export default function Discovery() {
   const [stories, setStories] = useState<Story[]>([]);
+  const [authorMap, setAuthorMap] = useState<Map<string, Author>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    getStories()
-      .then(setStories)
+    Promise.all([getStories(), getAuthors()])
+      .then(([s, a]) => {
+        setStories(s.filter((story) => story.publishedAt !== null));
+        setAuthorMap(new Map(a.map((auth) => [auth.githubUsername, auth])));
+      })
       .catch(() => setError('This library couldn\'t be loaded. Try reloading the page.'))
       .finally(() => setLoading(false));
   }, []);
@@ -47,6 +51,9 @@ export default function Discovery() {
                     {story.title}
                     {story.subtitle && <span style={styles.cardSubtitle}>: {story.subtitle}</span>}
                   </h2>
+                  {story.authorUsername && authorMap.has(story.authorUsername) && (
+                    <p className="story-author">by {authorMap.get(story.authorUsername)!.penName}</p>
+                  )}
                   {story.description && (
                     <p style={styles.cardDescription}>{story.description}</p>
                   )}
@@ -129,6 +136,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   cardSubtitle: {
     fontWeight: 400,
+    fontStyle: 'italic',
     color: 'var(--color-text-secondary)',
   },
   cardDescription: {

--- a/src/web/src/pages/reader/StoryTitle.tsx
+++ b/src/web/src/pages/reader/StoryTitle.tsx
@@ -1,20 +1,25 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { getStory } from '../../api';
-import type { Story } from '../../types';
+import { getStory, getAuthor } from '../../api';
+import type { Story, Author } from '../../types';
 
 export default function StoryTitle() {
   const { slug } = useParams<{ slug: string }>();
   const [story, setStory] = useState<Story | null>(null);
+  const [author, setAuthor] = useState<Author | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!slug) return;
     getStory(slug)
-      .then((s) => {
-        if (!s) setError('This story couldn\'t be found.');
-        else setStory(s);
+      .then(async (s) => {
+        if (!s) { setError('This story couldn\'t be found.'); return; }
+        setStory(s);
+        if (s.authorUsername) {
+          const a = await getAuthor(s.authorUsername);
+          setAuthor(a);
+        }
       })
       .catch(() => setError('This story couldn\'t be loaded. Try reloading the page.'))
       .finally(() => setLoading(false));
@@ -44,6 +49,7 @@ export default function StoryTitle() {
       <div style={styles.meta}>
         <h1 style={styles.title}>{story.title}</h1>
         {story.subtitle && <p style={styles.subtitle}>{story.subtitle}</p>}
+        {author && <p className="story-author" style={{ fontSize: 18 }}>by {author.penName}</p>}
 
         {story.description && (
           <p style={styles.description}>{story.description}</p>
@@ -120,6 +126,7 @@ const styles: Record<string, React.CSSProperties> = {
     fontFamily: 'Inter, sans-serif',
     fontWeight: 400,
     fontSize: 18,
+    fontStyle: 'italic',
     color: 'var(--color-text-secondary)',
     letterSpacing: '-0.2px',
     marginTop: -8,

--- a/src/web/src/types.ts
+++ b/src/web/src/types.ts
@@ -5,6 +5,14 @@ export interface AdminUser {
   addedAt: string;
 }
 
+export interface Author {
+  githubUsername: string;
+  fullName: string;
+  penName: string;
+  bio?: string;
+  profileImageUrl?: string;
+}
+
 export interface Chapter {
   id: string;
   storyId: string;
@@ -24,4 +32,5 @@ export interface Story {
   seriesOrder?: number;
   publishedAt: string | null;
   chapters: Chapter[];
+  authorUsername?: string;
 }


### PR DESCRIPTION
## Summary

- Introduces an `Author` entity linked 1:1 with each admin user, with `fullName`, `penName`, and placeholder fields (`bio`, `profileImageUrl`) ready for the future author profile page
- All stories now carry an `authorUsername`; pre-existing localStorage stories are migrated automatically on first admin page load
- Author attribution is locked once a story has been published — editable on drafts, read-only after publish
- Resolves issue #26 

## What changed

**Data layer**
- New `Author` type: `githubUsername`, `fullName`, `penName`, `bio?`, `profileImageUrl?`
- `authorUsername?` added to `Story` (optional for backward compat with pre-migration data)
- `getAuthors`, `getAuthor`, `updateAuthor` added to the mock API
- `addAdmin` now creates a paired author entry; `removeAdmin` removes it
- `migrateStoryAuthors(username)` patches any story missing `authorUsername` and persists — called on admin index mount

**Admin — Manage Admins (`/admin/admins`)**
- New "Author profiles" section below the admin table
- Inline edit per author row: full name (required), pen name (defaults to full name if blank)
- Rows stay in sync with the admin list — no orphaned author entries

**Admin — Stories**
- Author field on New Story and Edit Story forms
- Single admin: displays as read-only text. Multiple admins: dropdown defaulting to the logged-in user
- Selecting a different author surfaces a consent checkbox; submit is blocked until checked
- Edit Story: author field is read-only once the story is published, with a "(locked after publish)" label
- Admin story list now shows subtitle alongside title so duplicate-title entries are distinguishable

**Reader surfaces**
- Discovery cards show the author's pen name below the story title (published stories only — drafts are now filtered out)
- Story title page shows the author's pen name below the title at 18px, matching the subtitle size
- Subtitle is now rendered in italic on both Discovery cards and the story title page; author byline is regular weight

**Bug fixes**
- Discovery was showing draft stories to readers — now filters to `publishedAt !== null`
- Admin index crashed with `Cannot read properties of null (reading 'username')` on initial mount — effect now guards against null user and re-fires when auth resolves

**Design docs**
- `design/backlog.md` — new entry: Publication Audit Log (replace `publishedAt` flag with append-only `PublicationEvent[]`, author lock via `firstPublishedAt`, unpublish ceremony, archive/unpublish distinction)
- `design/security-concerns.md` — new file: env var classification, admin whitelist notes
- `design/architecture.md`, `design/deployment.md`, `design/aesthethic.md` — updates from prior sessions

## Test plan

- [ ] Visit `/` — only published stories appear; each card shows pen name and italic subtitle where applicable
- [ ] Visit a story title page — pen name appears below the title at a size matching the subtitle; subtitle is italic
- [ ] Log in as admin, visit `/admin` — stories load without error; subtitle visible next to title for same-named entries
- [ ] Visit `/admin/admins` — Author profiles section shows all admins with Edit button; saving requires full name; pen name defaults to full name if left blank
- [ ] Create a new story as the only admin — author field shows as read-only text
- [ ] (If multiple admins exist) Create a story selecting a different author — consent checkbox appears; submit blocked until checked
- [ ] Edit a draft story — author field is editable
- [ ] Publish a story, then edit it — author field is read-only
- [ ] Clear localStorage and reload `/admin` — seed stories are migrated to the current user as author