### PR TITLE
disable text selection (for now) on reading panel

### DIFF
--- a/design/backlog.md
+++ b/design/backlog.md
@@ -105,6 +105,65 @@ PublicationEvent {
 
 ---
 
+## Secure Content Delivery (IP Protection — Story 3)
+
+**As an author, I need chapter content to be impossible to bulk-scrape via direct API or storage access, so that my work cannot be programmatically extracted even by technically sophisticated actors.**
+
+### Why this is critical
+
+This must land **before blob storage goes live**. If Azure Blob Storage containers are set to public access, the content URLs are trivially discoverable and downloadable regardless of any client-side protections. `robots.txt` and `user-select: none` are irrelevant once someone has direct blob access.
+
+### Architecture requirement
+
+**Content must never live at a publicly accessible URL.** All chapter content is served exclusively through an Azure Function at `/api/chapters/{id}/content`. The function is the only entity with storage credentials.
+
+### Scope
+
+- [ ] Azure Blob Storage content container: **private** (no anonymous read access)
+- [ ] `GET /api/chapters/{id}/content` Azure Function: validates published status, fetches blob server-side, returns content body
+- [ ] Client `getChapterContent()` changes from fetching a blob URL to calling `/api/chapters/{id}/content`
+- [ ] Remove `blobPath` from any client-visible API response — it is an internal server detail only
+- [ ] Function-level hardening: reject missing/mismatched `Referer` header; reject known scraper `User-Agent` strings
+- [ ] Rate limiting: cap chapter content fetches per reader ID per hour (leverages reading history infrastructure)
+
+### Future / out of scope at this story
+
+- Reader authentication gating (serve content only to authenticated readers) — Phase 3
+- SAS URL generation for time-limited access — not needed if content is always proxied
+
+---
+
+## Reading Surface Watermark (IP Protection — Story 4)
+
+**As an author, I want screenshots of my content to be attributable, so that if my work appears elsewhere I can demonstrate it was accessed from this platform.**
+
+### Approach
+
+A low-opacity overlay on the `.page-card` reading surface displaying the reader's identifier and access date. Rendered via a CSS pseudo-element or `position: fixed` layer with `pointer-events: none` so it does not interfere with the reading experience.
+
+### Content
+
+- Reader identifier: anonymous UUID from `st-reader-id` (already implemented), or authenticated username when reader accounts exist
+- Access date
+- Site name / copyright line
+
+### Dependency
+
+The `getOrCreateReaderId()` function from `src/web/src/api/reader-identity.ts` is already built. This story is unblocked.
+
+### Limitation
+
+A cropped screenshot or AI inpainting can remove a watermark. Its primary value is legal: it establishes when and by whom content was accessed from this platform, supporting a DMCA or infringement claim.
+
+### Scope
+
+- [ ] Watermark overlay component or CSS layer on `.page-card`
+- [ ] Reader ID sourced from `getOrCreateReaderId()` (anonymous) or auth context (authenticated)
+- [ ] Opacity and styling that is visible in a screenshot without materially degrading the reading experience
+- [ ] Ensure watermark does not appear on admin-facing pages or the story title page
+
+---
+
 ## Image Upload (Admin)
 
 **As an admin, I want to upload cover and chapter images that are constrained to brand guidelines before being stored.**

--- a/src/web/public/robots.txt
+++ b/src/web/public/robots.txt
@@ -1,0 +1,21 @@
+User-agent: *
+Allow: /
+Disallow: /stories/*/chapters/
+
+# Known AI training crawlers — disallow chapter content
+User-agent: GPTBot
+Disallow: /stories/*/chapters/
+
+User-agent: ClaudeBot
+Disallow: /stories/*/chapters/
+
+User-agent: CCBot
+Disallow: /stories/*/chapters/
+
+User-agent: anthropic-ai
+Disallow: /stories/*/chapters/
+
+User-agent: Google-Extended
+Disallow: /stories/*/chapters/
+
+Crawl-delay: 10

--- a/src/web/public/staticwebapp.config.json
+++ b/src/web/public/staticwebapp.config.json
@@ -1,5 +1,12 @@
 {
-  "routes": [],
+  "routes": [
+    {
+      "route": "/stories/*/chapters/*",
+      "headers": {
+        "X-Robots-Tag": "noindex, nofollow"
+      }
+    }
+  ],
   "auth": {
     "identityProviders": {
       "github": {

--- a/src/web/public/staticwebapp.config.json
+++ b/src/web/public/staticwebapp.config.json
@@ -1,12 +1,5 @@
 {
-  "routes": [
-    {
-      "route": "/stories/*/chapters/*",
-      "headers": {
-        "X-Robots-Tag": "noindex, nofollow"
-      }
-    }
-  ],
+  "routes": [],
   "auth": {
     "identityProviders": {
       "github": {

--- a/src/web/src/index.css
+++ b/src/web/src/index.css
@@ -25,6 +25,11 @@ a:hover {
 }
 
 /* Prose body — chapter reading surface */
+.prose {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
 .prose p {
   margin-bottom: 1.5em;
 }

--- a/src/web/src/pages/reader/Chapter.tsx
+++ b/src/web/src/pages/reader/Chapter.tsx
@@ -15,6 +15,14 @@ export default function Chapter() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  useEffect(() => {
+    const meta = document.createElement('meta');
+    meta.name = 'robots';
+    meta.content = 'noindex, nofollow';
+    document.head.appendChild(meta);
+    return () => { document.head.removeChild(meta); };
+  }, []);
+
   // Capture enter direction once on mount — drives the slide-in animation
   const [enterClass] = useState<string>(() => {
     const from = (location.state as { from?: string } | null)?.from;

--- a/src/web/src/pages/reader/Chapter.tsx
+++ b/src/web/src/pages/reader/Chapter.tsx
@@ -95,7 +95,12 @@ export default function Chapter() {
             <div style={styles.rule} />
           </header>
 
-          <div className="prose" style={styles.prose}>
+          <div
+            className="prose"
+            style={styles.prose}
+            onCopy={(e) => e.preventDefault()}
+            onContextMenu={(e) => e.preventDefault()}
+          >
             <ReactMarkdown>{content}</ReactMarkdown>
           </div>
 


### PR DESCRIPTION
Resolves two easy IP Protection methods:

1. Disables content selection on the reading panel.
2. Explicitly tells bots not to crawl content pages; Title pages are still accessible; good metadata will be critical at the title page for SEO.

Resolves #41 
Resolves #42 