### PR TITLE
Feat/quick link last read

### DIFF
--- a/src/web/src/api/index.ts
+++ b/src/web/src/api/index.ts
@@ -1,4 +1,4 @@
-import type { Story, Chapter, AdminUser, Author, ReadingEvent } from '../types';
+import type { Story, Chapter, AdminUser, Author, ReadingEvent, Bookmark } from '../types';
 import { getOrCreateReaderId } from './reader-identity';
 import { getAuthUser } from './auth';
 
@@ -204,6 +204,64 @@ export async function getChapterContent(blobPath: string): Promise<string> {
   const res = await fetch(blobPath);
   if (!res.ok) throw new Error(`Failed to load chapter: ${res.status}`);
   return res.text();
+}
+
+// ── Bookmarks ────────────────────────────────────────────────────────────────────
+
+const BOOKMARK_EVENTS_KEY = 'st-story-bookmarks';
+
+function loadBookmarks(): Bookmark[] {
+  try {
+    const raw = localStorage.getItem(BOOKMARK_EVENTS_KEY);
+    if (raw) return JSON.parse(raw) as Bookmark[];
+  } catch {}
+  return [];
+}
+
+function saveBookmarks(events: Bookmark[]): void {
+  try {
+    localStorage.setItem(BOOKMARK_EVENTS_KEY, JSON.stringify(events));
+  } catch {}
+}
+export async function placeBookmark(
+  chapter: Pick<Chapter, 'id' | 'storyId' | 'order'>,
+  storySlug: string,
+): Promise<void> {
+  const authUser = await getAuthUser();
+  const readerId = authUser?.userId ?? getOrCreateReaderId();
+  const event: Bookmark = {
+    id: crypto.randomUUID(),
+    readerId,
+    storyId: chapter.storyId,
+    chapterId: chapter.id,
+    storySlug,
+    chapterOrder: chapter.order,
+    occurredAt: new Date().toISOString(),
+  };
+  const events = loadBookmarks().filter((e) => e.storyId !== chapter.storyId);
+  events.push(event);
+  saveBookmarks(events);
+}
+
+export async function getBookmarks(filters?: {
+  readerId?: string;
+  storyId?: string;
+  chapterId?: string;
+  from?: string;
+  to?: string;
+}): Promise<Bookmark[]> {
+  let events = loadBookmarks();
+  if (!filters) return events;
+  if (filters.readerId)  events = events.filter((e) => e.readerId === filters.readerId);
+  if (filters.storyId)   events = events.filter((e) => e.storyId === filters.storyId);
+  if (filters.chapterId) events = events.filter((e) => e.chapterId === filters.chapterId);
+  if (filters.from)      events = events.filter((e) => e.occurredAt >= filters.from!);
+  if (filters.to)        events = events.filter((e) => e.occurredAt <= filters.to!);
+  return events;
+}
+
+export async function removeBookmark(chapterId: string): Promise<void> {
+  saveBookmarks(loadBookmarks().filter((e) => e.chapterId !== chapterId));
 }
 
 // ── Stories ─────────────────────────────────────────────────────────────────

--- a/src/web/src/components/ReaderPanel.tsx
+++ b/src/web/src/components/ReaderPanel.tsx
@@ -3,12 +3,14 @@ import { Link } from 'react-router-dom';
 
 export interface ReaderPanelItem {
   label: string;
+  sublabel?: string;
   href: string;
 }
 
 export interface ReaderPanelSection {
   id: string;
   heading: string;
+  icon?: React.ReactNode;
   items: ReaderPanelItem[];
   hasMore?: boolean;
 }
@@ -75,13 +77,19 @@ export default function ReaderPanel({ sections, onScrollEdge }: Props) {
       onClickCapture={onClickCapture}
     >
       {sections.map((section) => (
-        <div key={section.heading} className="reader-panel-section">
-          <h2 className="reader-panel-heading">{section.heading}</h2>
+        <div key={section.id} className="reader-panel-section">
+          <div className="reader-panel-heading-row">
+            <h2 className="reader-panel-heading">{section.heading}</h2>
+            {section.icon && <span className="reader-panel-section-icon">{section.icon}</span>}
+          </div>
           <hr style={{ border: 'none', borderTop: '1px solid var(--color-border)', margin: 0 }} />
           <ul className="reader-panel-list">
             {section.items.map((item) => (
               <li key={item.href} className="reader-panel-item">
-                <Link to={item.href} draggable={false}>{item.label}</Link>
+                <Link to={item.href} draggable={false} className="reader-panel-item-link">
+                  <span className="reader-panel-item-label">{item.label}</span>
+                  {item.sublabel && <span className="reader-panel-item-sublabel">{item.sublabel}</span>}
+                </Link>
               </li>
             ))}
           </ul>

--- a/src/web/src/index.css
+++ b/src/web/src/index.css
@@ -525,6 +525,12 @@ textarea.input {
   flex-shrink: 0;
 }
 
+.reader-panel-heading-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .reader-panel-heading {
   font-family: 'Inter', sans-serif;
   font-size: 11px;
@@ -532,6 +538,13 @@ textarea.input {
   color: var(--color-text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+
+.reader-panel-section-icon {
+  display: flex;
+  align-items: center;
+  color: var(--color-text-secondary);
+  flex-shrink: 0;
 }
 
 .reader-panel-list {
@@ -542,6 +555,16 @@ textarea.input {
 }
 
 .reader-panel-item {
+  overflow: hidden;
+}
+
+.reader-panel-item-link {
+  display: block;
+  text-decoration: none;
+}
+
+.reader-panel-item-label {
+  display: block;
   font-family: 'Inter', sans-serif;
   font-size: 14px;
   color: var(--color-text-primary);
@@ -550,12 +573,18 @@ textarea.input {
   text-overflow: ellipsis;
 }
 
-.reader-panel-item a {
-  color: var(--color-text-primary);
-  text-decoration: none;
+.reader-panel-item-sublabel {
+  display: block;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 2px;
 }
 
-.reader-panel-item a:hover {
+.reader-panel-item-link:hover .reader-panel-item-label {
   color: var(--color-accent);
 }
 

--- a/src/web/src/pages/reader/Chapter.tsx
+++ b/src/web/src/pages/reader/Chapter.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link, useParams, useNavigate, useLocation } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import { useSwipeable } from 'react-swipeable';
-import { getStory, getChapterContent, logReadingEvent } from '../../api';
+import { getStory, getChapterContent, logReadingEvent, getBookmarks, placeBookmark, removeBookmark } from '../../api';
 import type { Story, Chapter as ChapterType } from '../../types';
 
 export default function Chapter() {
@@ -14,6 +14,7 @@ export default function Chapter() {
   const [content, setContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isBookmarked, setIsBookmarked] = useState(false);
 
   useEffect(() => {
     const meta = document.createElement('meta');
@@ -46,10 +47,22 @@ export default function Chapter() {
         const text = await getChapterContent(ch.blobPath);
         setContent(text);
         logReadingEvent(ch, slug).catch(() => { /* logging failure must not affect reading */ });
+        getBookmarks({ chapterId: ch.id }).then((bm) => setIsBookmarked(bm.length > 0));
       })
       .catch(() => setError('This content couldn\'t be loaded. Try reloading the page.'))
       .finally(() => setLoading(false));
   }, [slug, chapterId]);
+
+  async function toggleBookmark() {
+    if (!chapter || !slug) return;
+    if (isBookmarked) {
+      await removeBookmark(chapter.id);
+      setIsBookmarked(false);
+    } else {
+      await placeBookmark(chapter, slug);
+      setIsBookmarked(true);
+    }
+  }
 
   const sorted = story?.chapters.slice().sort((a, b) => a.order - b.order) ?? [];
   const currentIndex = sorted.findIndex((c) => c.id === chapterId);
@@ -88,9 +101,25 @@ export default function Chapter() {
     <div style={styles.outer}>
       <div style={styles.inner}>
         <nav style={styles.topNav}>
-          <Link to={`/stories/${story.slug}`} style={styles.navLink}>
-            ← {story.title}{story.subtitle ? `: ${story.subtitle}` : ''}
-          </Link>
+          <div style={styles.breadcrumb}>
+            <Link to="/" style={styles.breadcrumbLink}>Home</Link>
+            <span style={styles.breadcrumbSep}>›</span>
+            <Link to={`/stories/${story.slug}`} style={styles.breadcrumbLink}>
+              {story.title}{story.subtitle ? `: ${story.subtitle}` : ''}
+            </Link>
+            <span style={styles.breadcrumbSep}>›</span>
+            <span style={styles.breadcrumbCurrent}>Chapter {chapter.order}</span>
+          </div>
+          <button
+            onClick={toggleBookmark}
+            style={styles.bookmarkBtn}
+            aria-label={isBookmarked ? 'Remove bookmark' : 'Bookmark this chapter'}
+            title={isBookmarked ? 'Remove bookmark' : 'Bookmark this chapter'}
+          >
+            <svg width="16" height="16" viewBox="0 0 14 14" fill={isBookmarked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: isBookmarked ? 'var(--color-accent)' : 'var(--color-text-secondary)' }}>
+              <path d="M3 2h8a1 1 0 0 1 1 1v9l-5-3-5 3V3a1 1 0 0 1 1-1z" />
+            </svg>
+          </button>
         </nav>
 
         <div
@@ -160,6 +189,44 @@ const styles: Record<string, React.CSSProperties> = {
   },
   topNav: {
     marginBottom: 20,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  breadcrumb: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    flexWrap: 'wrap',
+    minWidth: 0,
+  },
+  breadcrumbLink: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: 13,
+    color: 'var(--color-text-secondary)',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap',
+  },
+  breadcrumbSep: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: 13,
+    color: 'var(--color-border)',
+  },
+  breadcrumbCurrent: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: 13,
+    color: 'var(--color-text-primary)',
+    whiteSpace: 'nowrap',
+  },
+  bookmarkBtn: {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    padding: 4,
+    display: 'flex',
+    alignItems: 'center',
+    lineHeight: 1,
   },
   articleHeader: {
     marginBottom: 40,

--- a/src/web/src/pages/reader/Discovery.tsx
+++ b/src/web/src/pages/reader/Discovery.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getStories, getAuthors, getAuthor, getReadingEvents } from '../../api';
+import { getStories, getAuthors, getAuthor, getReadingEvents, getBookmarks } from '../../api';
 import { getAuthUser } from '../../api/auth';
 import { getPreferences, PANEL_SECTION_REGISTRY } from '../../api/preferences';
 import type { Story, Author } from '../../types';
@@ -69,16 +69,6 @@ const SparkleIcon = () => (
 // TODO: replace with real data once bookmarks, favorites, and reading-list APIs are built
 const PLACEHOLDER_SECTIONS: ReaderPanelSection[] = [
   {
-    id: 'bookmarks',
-    heading: 'Bookmarks',
-    icon: <BookmarkIcon />,
-    items: [
-      { label: 'Chapter 1 · The Silver Thread', sublabel: 'The Silver Thread', href: '/stories/the-silver-thread/chapters/ch1' },
-      { label: 'Chapter 2 · The Silver Thread: Wedding Bells', sublabel: 'The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread-wedding-bells/chapters/ch2' },
-    ],
-    hasMore: false,
-  },
-  {
     id: 'favorite-stories',
     heading: 'Favorite Stories',
     icon: <HeartIcon />,
@@ -122,6 +112,7 @@ export default function Discovery() {
 
   const [panelAtEnd, setPanelAtEnd] = useState(false);
   const [lastReadSection, setLastReadSection] = useState<ReaderPanelSection | null>(null);
+  const [latestBookmarkSection, setLatestBookmarkSection] = useState<ReaderPanelSection | null>(null);
   const prefs = getPreferences();
 
   useEffect(() => {
@@ -133,8 +124,8 @@ export default function Discovery() {
       setWelcomeName(firstName);
     });
 
-    Promise.all([getStories(), getAuthors(), getReadingEvents()])
-      .then(([s, a, events]) => {
+    Promise.all([getStories(), getAuthors(), getReadingEvents(), getBookmarks()])
+      .then(([s, a, events, bookmarks]) => {
         const publishedStories = s.filter((story) => story.publishedAt !== null);
         setStories(publishedStories);
         setAuthorMap(new Map(a.map((auth) => [auth.githubUsername, auth])));
@@ -151,6 +142,27 @@ export default function Discovery() {
               id: 'pick-up',
               heading: 'Last Read',
               icon: <ClockIcon />,
+              items: [{
+                label: story.subtitle ? `${story.title}: ${story.subtitle}` : story.title,
+                sublabel: `Chapter ${chapter.order} · ${chapter.title}`,
+                href: `/stories/${story.slug}/chapters/${chapter.id}`,
+              }],
+              hasMore: false,
+            });
+          }
+        }
+
+        if (bookmarks.length > 0) {
+          const latest = [...bookmarks].sort((a, b) =>
+            new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()
+          )[0];
+          const story = publishedStories.find((s) => s.slug === latest.storySlug);
+          const chapter = story?.chapters.find((c) => c.id === latest.chapterId);
+          if (story && chapter) {
+            setLatestBookmarkSection({
+              id: 'bookmarks',
+              heading: 'Bookmarks',
+              icon: <BookmarkIcon />,
               items: [{
                 label: story.subtitle ? `${story.title}: ${story.subtitle}` : story.title,
                 sublabel: `Chapter ${chapter.order} · ${chapter.title}`,
@@ -242,6 +254,7 @@ export default function Discovery() {
           <ReaderPanel
             sections={[
               ...(lastReadSection ? [lastReadSection] : []),
+              ...(latestBookmarkSection ? [latestBookmarkSection] : []),
               ...PLACEHOLDER_SECTIONS,
             ].filter((s) => {
               const config = PANEL_SECTION_REGISTRY.find((r) => r.id === s.id);

--- a/src/web/src/pages/reader/Discovery.tsx
+++ b/src/web/src/pages/reader/Discovery.tsx
@@ -1,57 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getStories, getAuthors, getAuthor } from '../../api';
+import { getStories, getAuthors, getAuthor, getReadingEvents } from '../../api';
 import { getAuthUser } from '../../api/auth';
 import { getPreferences, PANEL_SECTION_REGISTRY } from '../../api/preferences';
 import type { Story, Author } from '../../types';
 import ReaderPanel, { type ReaderPanelSection } from '../../components/ReaderPanel';
-
-// TODO: replace with real data from reading history, bookmarks, and favorites APIs
-const PLACEHOLDER_SECTIONS: ReaderPanelSection[] = [
-  {
-    id: 'pick-up',
-    heading: 'Last Read',
-    items: [
-      { label: 'Chapter 2 · The Silver Thread', href: '/stories/the-silver-thread/chapters/ch2' },
-    ],
-    hasMore: false,
-  },
-  {
-    id: 'bookmarks',
-    heading: 'Bookmarks',
-    items: [
-      { label: 'Chapter 1 · The Silver Thread', href: '/stories/the-silver-thread/chapters/ch1' },
-      { label: 'Chapter 2 · The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread/chapters-wedding-bells/ch2' },
-    ],
-    hasMore: false,
-  },
-  {
-    id: 'favorite-stories',
-    heading: 'Favorite Stories',
-    items: [
-      { label: 'The Silver Thread', href: '/stories/the-silver-thread' },
-      { label: 'The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread-wedding-bells' },
-    ],
-    hasMore: false,
-  },
-  {
-    id: 'reading-list',
-    heading: 'Reading List',
-    items: [
-      { label: 'The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread-wedding-bells' },
-      { label: 'The Silver Thread', href: '/stories/the-silver-thread' },
-    ],
-    hasMore: false,
-  },
-  {
-    id: 'new-this-week',
-    heading: 'New This Week',
-    items: [
-      { label: 'The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread-wedding-bells' },
-    ],
-    hasMore: false,
-  },
-];
 
 const Hamburger = () => (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round">
@@ -79,6 +32,83 @@ const SlidersIcon = () => (
   </svg>
 );
 
+const ClockIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="7" cy="7" r="5.5" />
+    <polyline points="7,4 7,7 9,9" />
+  </svg>
+);
+
+const BookmarkIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 2h8a1 1 0 0 1 1 1v9l-5-3-5 3V3a1 1 0 0 1 1-1z" />
+  </svg>
+);
+
+const HeartIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M7 12S1.5 8 1.5 4.5a3 3 0 0 1 5.5-1.6 3 3 0 0 1 5.5 1.6C12.5 8 7 12 7 12z" />
+  </svg>
+);
+
+const ListIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+    <line x1="1" y1="3.5" x2="13" y2="3.5" />
+    <line x1="1" y1="7"   x2="13" y2="7"   />
+    <line x1="1" y1="10.5" x2="13" y2="10.5" />
+  </svg>
+);
+
+const SparkleIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M7 1v2M7 11v2M1 7h2M11 7h2M3 3l1.5 1.5M9.5 9.5 11 11M11 3l-1.5 1.5M4.5 9.5 3 11" />
+    <circle cx="7" cy="7" r="2" />
+  </svg>
+);
+
+// TODO: replace with real data once bookmarks, favorites, and reading-list APIs are built
+const PLACEHOLDER_SECTIONS: ReaderPanelSection[] = [
+  {
+    id: 'bookmarks',
+    heading: 'Bookmarks',
+    icon: <BookmarkIcon />,
+    items: [
+      { label: 'Chapter 1 · The Silver Thread', sublabel: 'The Silver Thread', href: '/stories/the-silver-thread/chapters/ch1' },
+      { label: 'Chapter 2 · The Silver Thread: Wedding Bells', sublabel: 'The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread-wedding-bells/chapters/ch2' },
+    ],
+    hasMore: false,
+  },
+  {
+    id: 'favorite-stories',
+    heading: 'Favorite Stories',
+    icon: <HeartIcon />,
+    items: [
+      { label: 'The Silver Thread', href: '/stories/the-silver-thread' },
+      { label: 'The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread-wedding-bells' },
+    ],
+    hasMore: false,
+  },
+  {
+    id: 'reading-list',
+    heading: 'Reading List',
+    icon: <ListIcon />,
+    items: [
+      { label: 'The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread-wedding-bells' },
+      { label: 'The Silver Thread', href: '/stories/the-silver-thread' },
+    ],
+    hasMore: false,
+  },
+  {
+    id: 'new-this-week',
+    heading: 'New This Week',
+    icon: <SparkleIcon />,
+    items: [
+      { label: 'The Silver Thread: Wedding Bells', href: '/stories/the-silver-thread-wedding-bells' },
+    ],
+    hasMore: false,
+  },
+];
+
 export default function Discovery() {
   const [stories, setStories] = useState<Story[]>([]);
   const [authorMap, setAuthorMap] = useState<Map<string, Author>>(new Map());
@@ -91,6 +121,7 @@ export default function Discovery() {
   const profileRef = useRef<HTMLDivElement>(null);
 
   const [panelAtEnd, setPanelAtEnd] = useState(false);
+  const [lastReadSection, setLastReadSection] = useState<ReaderPanelSection | null>(null);
   const prefs = getPreferences();
 
   useEffect(() => {
@@ -102,10 +133,33 @@ export default function Discovery() {
       setWelcomeName(firstName);
     });
 
-    Promise.all([getStories(), getAuthors()])
-      .then(([s, a]) => {
-        setStories(s.filter((story) => story.publishedAt !== null));
+    Promise.all([getStories(), getAuthors(), getReadingEvents()])
+      .then(([s, a, events]) => {
+        const publishedStories = s.filter((story) => story.publishedAt !== null);
+        setStories(publishedStories);
         setAuthorMap(new Map(a.map((auth) => [auth.githubUsername, auth])));
+
+        if (events.length > 0) {
+          setBannerTitle('Discover More');
+          const latest = [...events].sort((a, b) =>
+            new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()
+          )[0];
+          const story = publishedStories.find((s) => s.slug === latest.storySlug);
+          const chapter = story?.chapters.find((c) => c.id === latest.chapterId);
+          if (story && chapter) {
+            setLastReadSection({
+              id: 'pick-up',
+              heading: 'Last Read',
+              icon: <ClockIcon />,
+              items: [{
+                label: story.subtitle ? `${story.title}: ${story.subtitle}` : story.title,
+                sublabel: `Chapter ${chapter.order} · ${chapter.title}`,
+                href: `/stories/${story.slug}/chapters/${chapter.id}`,
+              }],
+              hasMore: false,
+            });
+          }
+        }
       })
       .catch(() => setError('This library couldn\'t be loaded. Try reloading the page.'))
       .finally(() => setLoading(false));
@@ -116,12 +170,6 @@ export default function Discovery() {
       }
     };
     document.addEventListener('mousedown', handleOutsideClick);
-
-    // TODO: replace with getReadingEvents() once reading history module is restored
-    try {
-      const raw = localStorage.getItem('st-reading-events');
-      if (raw && (JSON.parse(raw) as unknown[]).length > 0) setBannerTitle('Discover More');
-    } catch { /* leave default */ }
 
     return () => document.removeEventListener('mousedown', handleOutsideClick);
   }, []);
@@ -192,7 +240,10 @@ export default function Discovery() {
       <div style={styles.page}>
         <div className={`reader-panel-wrapper${panelAtEnd ? ' at-end' : ''}`}>
           <ReaderPanel
-            sections={PLACEHOLDER_SECTIONS.filter((s) => {
+            sections={[
+              ...(lastReadSection ? [lastReadSection] : []),
+              ...PLACEHOLDER_SECTIONS,
+            ].filter((s) => {
               const config = PANEL_SECTION_REGISTRY.find((r) => r.id === s.id);
               if (!config) return false;
               if (config.requiresAuth && !authUsername) return false;

--- a/src/web/src/pages/reader/StoryTitle.tsx
+++ b/src/web/src/pages/reader/StoryTitle.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { getStory, getAuthor } from '../../api';
-import type { Story, Author } from '../../types';
+import { getStory, getAuthor, getBookmarks, getReadingEvents } from '../../api';
+import type { Story, Author, Bookmark, Chapter as ChapterType } from '../../types';
 
 export default function StoryTitle() {
   const { slug } = useParams<{ slug: string }>();
   const [story, setStory] = useState<Story | null>(null);
   const [author, setAuthor] = useState<Author | null>(null);
+  const [bookmark, setBookmark] = useState<Bookmark | null>(null);
+  const [lastReadChapter, setLastReadChapter] = useState<ChapterType | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -16,9 +18,18 @@ export default function StoryTitle() {
       .then(async (s) => {
         if (!s) { setError('This story couldn\'t be found.'); return; }
         setStory(s);
-        if (s.authorUsername) {
-          const a = await getAuthor(s.authorUsername);
-          setAuthor(a);
+        const [a, bm, events] = await Promise.all([
+          s.authorUsername ? getAuthor(s.authorUsername) : Promise.resolve(null),
+          getBookmarks({ storyId: s.id }),
+          getReadingEvents({ storyId: s.id }),
+        ]);
+        setAuthor(a);
+        setBookmark(bm[0] ?? null);
+        if (events.length > 0) {
+          const latest = [...events].sort((a, b) =>
+            new Date(b.occurredAt).getTime() - new Date(a.occurredAt).getTime()
+          )[0];
+          setLastReadChapter(s.chapters.find((c) => c.id === latest.chapterId) ?? null);
         }
       })
       .catch(() => setError('This story couldn\'t be loaded. Try reloading the page.'))
@@ -38,11 +49,17 @@ export default function StoryTitle() {
     </div>
   );
 
-  const firstChapter = story.chapters[0];
+  const sortedChapters = story.chapters.slice().sort((a, b) => a.order - b.order);
+  const firstChapter = sortedChapters[0];
+  const bookmarkedChapter = bookmark ? story.chapters.find((c) => c.id === bookmark.chapterId) : null;
 
   return (
     <div style={styles.page}>
-      <Link to="/" style={styles.backLink}>← All stories</Link>
+      <nav style={styles.breadcrumb}>
+        <Link to="/" style={styles.breadcrumbLink}>Home</Link>
+        <span style={styles.breadcrumbSep}>›</span>
+        <span style={styles.breadcrumbCurrent}>{story.title}{story.subtitle ? `: ${story.subtitle}` : ''}</span>
+      </nav>
 
       {story.coverImageUrl ? (
         <img src={story.coverImageUrl} alt={`Cover — ${story.title}`} style={{ ...styles.cover, objectFit: 'cover', display: 'block' }} />
@@ -65,7 +82,32 @@ export default function StoryTitle() {
           ))}
         </div>
 
-        {firstChapter && (
+        {bookmarkedChapter ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <Link to={`/stories/${story.slug}/chapters/${bookmarkedChapter.id}`} style={styles.beginButton}>
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="currentColor" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 2h8a1 1 0 0 1 1 1v9l-5-3-5 3V3a1 1 0 0 1 1-1z" />
+              </svg>
+              Chapter {bookmarkedChapter.order} · {bookmarkedChapter.title}
+            </Link>
+            {firstChapter && firstChapter.id !== bookmarkedChapter.id && (
+              <Link to={`/stories/${story.slug}/chapters/${firstChapter.id}`} style={styles.restartLink}>
+                Start from the beginning
+              </Link>
+            )}
+          </div>
+        ) : lastReadChapter ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+            <Link to={`/stories/${story.slug}/chapters/${lastReadChapter.id}`} style={styles.beginButton}>
+              Continue — Chapter {lastReadChapter.order} · {lastReadChapter.title}
+            </Link>
+            {firstChapter && firstChapter.id !== lastReadChapter.id && (
+              <Link to={`/stories/${story.slug}/chapters/${firstChapter.id}`} style={styles.restartLink}>
+                Start from the beginning
+              </Link>
+            )}
+          </div>
+        ) : firstChapter && (
           <Link to={`/stories/${story.slug}/chapters/${firstChapter.id}`} style={styles.beginButton}>
             Begin reading
           </Link>
@@ -159,7 +201,9 @@ const styles: Record<string, React.CSSProperties> = {
     textTransform: 'lowercase',
   },
   beginButton: {
-    display: 'inline-block',
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 8,
     fontFamily: 'Inter, sans-serif',
     fontSize: 14,
     fontWeight: 500,
@@ -167,6 +211,12 @@ const styles: Record<string, React.CSSProperties> = {
     background: 'var(--color-accent)',
     borderRadius: 4,
     padding: '10px 20px',
+    textDecoration: 'none',
+  },
+  restartLink: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: 13,
+    color: 'var(--color-text-secondary)',
     textDecoration: 'none',
   },
   divider: {
@@ -212,11 +262,27 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 15,
     color: 'var(--color-text-primary)',
   },
-  backLink: {
+  breadcrumb: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 8,
+  },
+  breadcrumbLink: {
     fontFamily: 'Inter, sans-serif',
     fontSize: 13,
     color: 'var(--color-text-secondary)',
     textDecoration: 'none',
+  },
+  breadcrumbSep: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: 13,
+    color: 'var(--color-border)',
+  },
+  breadcrumbCurrent: {
+    fontFamily: 'Inter, sans-serif',
+    fontSize: 13,
+    color: 'var(--color-text-primary)',
   },
   centered: {
     display: 'flex',

--- a/src/web/src/types.ts
+++ b/src/web/src/types.ts
@@ -45,3 +45,13 @@ export interface Story {
   chapters: Chapter[];
   authorUsername?: string;
 }
+
+export interface Bookmark {
+  id: string;
+  readerId: string;
+  storyId: string;
+  chapterId: string;
+  storySlug: string;
+  chapterOrder: number;
+  occurredAt: string;
+}


### PR DESCRIPTION
# Bookmarks
Resolves #21 

Introduces chapter-level bookmarking across the reader surfaces — data model, API, chapter page toggle, story title page CTA, and Discovery panel quick link.

# What changed
Data model — new Bookmark interface in types.ts, structurally identical to ReadingEvent. Stored in localStorage under st-story-bookmarks.

# API (api/index.ts) 
— four new functions: placeBookmark, getBookmarks, removeBookmark, and the storage helpers. placeBookmark enforces one bookmark per story by evicting any existing bookmark for the same storyId before writing the new one — keeping the invariant in the storage layer rather than in calling code.

# Chapter page (Chapter.tsx)
 — bookmark toggle button in the top-right of the chapter nav bar, alongside the new breadcrumb. Outline when unmarked, filled accent when active. Loads bookmark state on chapter mount; toggles optimistically on click.

# Story title page (StoryTitle.tsx) 
— primary CTA now resolves through a three-state priority:

1. Bookmark exists → Resume — Chapter N · Title + "Start from the beginning" (if not ch. 1)
2. No bookmark, read history exists → Continue — Chapter N · Title + "Start from the beginning"
3. Neither → Begin reading

* Reading events are filtered by storyId so the "Continue" CTA reflects progress in this story specifically, not the most recent chapter opened site-wide.

* Discovery panel (Discovery.tsx) — "Bookmarks" quick link section is now live data. Shows the most recently placed bookmark across all stories. Replaces the previous placeholder.

Design decisions worth noting
One bookmark per story is a storage invariant, not a display filter. No active flag; stale bookmarks are deleted at write time.
Bookmark history is intentionally not retained — ReadingEvent already captures chapter-open history. A bookmark is a position marker, not an activity log.