### PR TITLE
introduce note change history to see where defect overwrote notes

### DIFF
--- a/src/api/src/functions/planning.ts
+++ b/src/api/src/functions/planning.ts
@@ -2,7 +2,7 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/fu
 import { randomUUID } from 'crypto';
 import { isAdmin, getCallerUsername } from '../lib/table-client';
 import {
-  appendEvent, replayEvents, getUserIndex, updateUserIndex,
+  appendEvent, replayEvents, readEvents, getUserIndex, updateUserIndex,
   PersistedEvent, SlotArea,
 } from '../lib/event-store';
 
@@ -250,6 +250,19 @@ async function saveChapterDraft(request: HttpRequest, context: InvocationContext
   }
 }
 
+async function getProjectEvents(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+
+  const projectId = request.params.projectId;
+  try {
+    const { events } = await readEvents(projectId);
+    return { status: 200, jsonBody: { events } };
+  } catch (err: any) {
+    context.error('getProjectEvents error:', err);
+    return { status: 500, jsonBody: { message: 'Failed to load events' } };
+  }
+}
+
 // ── Registration ──────────────────────────────────────────────────────────────
 
 app.http('createProject', {
@@ -271,6 +284,13 @@ app.http('appendProjectEvent', {
   authLevel: 'anonymous',
   route: 'planning/projects/{projectId}/events',
   handler: appendProjectEvent,
+});
+
+app.http('getProjectEvents', {
+  methods: ['GET'],
+  authLevel: 'anonymous',
+  route: 'planning/projects/{projectId}/events',
+  handler: getProjectEvents,
 });
 
 app.http('getProjection', {

--- a/src/api/src/lib/event-store.ts
+++ b/src/api/src/lib/event-store.ts
@@ -121,7 +121,7 @@ async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
 
 // ── Event log ─────────────────────────────────────────────────────────────────
 
-async function readEvents(projectId: string): Promise<{ events: PersistedEvent[]; etag: string | undefined }> {
+export async function readEvents(projectId: string): Promise<{ events: PersistedEvent[]; etag: string | undefined }> {
   const blob = await getBlob(`projects/${projectId}/events.json`);
   try {
     const download = await blob.download();

--- a/src/web/src/api/planning.ts
+++ b/src/web/src/api/planning.ts
@@ -1,4 +1,4 @@
-import type { ProjectListItem, Projection, WritingEvent } from '../types';
+import type { ProjectListItem, Projection, WritingEvent, PersistedEvent } from '../types';
 
 async function apiFetch(path: string, options?: RequestInit) {
   const res = await fetch(`/api/planning/${path}`, {
@@ -40,6 +40,11 @@ export async function appendEvent(
 
 export async function getProjection(projectId: string): Promise<Projection> {
   return apiFetch(`projects/${projectId}/projection`);
+}
+
+export async function getProjectEvents(projectId: string): Promise<PersistedEvent[]> {
+  const data = await apiFetch(`projects/${projectId}/events`);
+  return data.events ?? [];
 }
 
 export async function getChapterDraft(projectId: string, chapterId: string): Promise<string> {

--- a/src/web/src/components/author/BlockDetailContent.tsx
+++ b/src/web/src/components/author/BlockDetailContent.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import TagInput from '../TagInput';
-import { appendEvent } from '../../api/planning';
-import type { Block, BlockColor, BlockStatus, Projection, Slot } from '../../types';
+import { appendEvent, getProjectEvents } from '../../api/planning';
+import type { Block, BlockColor, BlockStatus, PersistedEvent, Projection, Slot } from '../../types';
 
 const COLORS: BlockColor[] = ['amber', 'teal', 'coral', 'purple', 'blue'];
 const COLOR_HEX: Record<BlockColor, string> = {
@@ -11,6 +11,118 @@ const COLOR_HEX: Record<BlockColor, string> = {
 const STATUS_LABELS: Record<BlockStatus, string> = {
   active: 'active', hidden: 'hidden', parked: 'parked', archived: 'archived',
 };
+
+// ── History helpers ───────────────────────────────────────────────────────────
+
+type DiffLine = { kind: 'context' | 'add' | 'remove'; line: string };
+
+function lcs(a: string[], b: string[]): number[][] {
+  const m = a.length, n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      dp[i][j] = a[i - 1] === b[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1]);
+  return dp;
+}
+
+function computeLineDiff(before: string, after: string): DiffLine[] {
+  const a = before.split('\n');
+  const b = after.split('\n');
+  const dp = lcs(a, b);
+  const result: DiffLine[] = [];
+
+  function walk(i: number, j: number) {
+    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+      walk(i - 1, j - 1);
+      result.push({ kind: 'context', line: a[i - 1] });
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      walk(i, j - 1);
+      result.push({ kind: 'add', line: b[j - 1] });
+    } else if (i > 0) {
+      walk(i - 1, j);
+      result.push({ kind: 'remove', line: a[i - 1] });
+    }
+  }
+
+  walk(a.length, b.length);
+  return result;
+}
+
+function compactDiff(lines: DiffLine[], contextLines = 2): DiffLine[] {
+  const changed = new Set(lines.map((l, i) => l.kind !== 'context' ? i : -1).filter(i => i >= 0));
+  if (changed.size === 0) return [];
+  const keep = new Set<number>();
+  for (const idx of changed) {
+    for (let k = Math.max(0, idx - contextLines); k <= Math.min(lines.length - 1, idx + contextLines); k++) {
+      keep.add(k);
+    }
+  }
+  const compact: DiffLine[] = [];
+  let lastKept = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (!keep.has(i)) continue;
+    if (lastKept !== -1 && i > lastKept + 1) compact.push({ kind: 'context', line: '…' });
+    compact.push(lines[i]);
+    lastKept = i;
+  }
+  return compact;
+}
+
+interface HistoryItem {
+  id: string;
+  timestamp: string;
+  label: string;
+  prevNotes?: string;
+  nextNotes?: string;
+}
+
+function buildHistory(events: PersistedEvent[], blockId: string): HistoryItem[] {
+  const items: HistoryItem[] = [];
+  let prevNotes = '';
+
+  for (const ev of events) {
+    const p = ev.payload as Record<string, unknown>;
+    if (p.blockId !== blockId && ev.type !== 'BlockCreated') continue;
+
+    switch (ev.type) {
+      case 'BlockCreated':
+        if (p.blockId !== blockId) break;
+        items.push({ id: ev.id, timestamp: ev.timestamp, label: 'created' });
+        break;
+      case 'BlockUpdated': {
+        if (p.title !== undefined)
+          items.push({ id: ev.id, timestamp: ev.timestamp, label: `renamed to "${p.title}"` });
+        if (p.notes !== undefined) {
+          items.push({ id: ev.id, timestamp: ev.timestamp, label: 'notes updated', prevNotes, nextNotes: p.notes as string });
+          prevNotes = p.notes as string;
+        }
+        break;
+      }
+      case 'BlockMoved':
+        items.push({ id: ev.id, timestamp: ev.timestamp, label: `moved to ${p.toSlot}` });
+        break;
+      case 'BlockAssigned':
+        items.push({ id: ev.id, timestamp: ev.timestamp, label: `assigned to outline: ${p.toSlot}` });
+        break;
+      case 'BlockUnassigned':
+        items.push({ id: ev.id, timestamp: ev.timestamp, label: `removed from outline: ${p.fromSlot}` });
+        break;
+      case 'BlockPinned':
+        items.push({ id: ev.id, timestamp: ev.timestamp, label: 'pinned' });
+        break;
+      case 'BlockUnpinned':
+        items.push({ id: ev.id, timestamp: ev.timestamp, label: 'unpinned' });
+        break;
+      case 'BlockStatusChanged':
+        items.push({ id: ev.id, timestamp: ev.timestamp, label: `status → ${p.status}` });
+        break;
+    }
+  }
+
+  return items.reverse();
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
 
 interface Props {
   block: Block;
@@ -31,6 +143,11 @@ export default function BlockDetailContent({ block, projection, projectId, onRef
   const savedNotes = useRef(block.notes ?? '');
   const savedLinks = useRef(block.links ?? []);
 
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [historyItems, setHistoryItems] = useState<HistoryItem[] | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [expandedDiffs, setExpandedDiffs] = useState<Set<string>>(new Set());
+
   // Track current field values in refs so the unmount cleanup can read them
   // without stale closure values (effect with [] deps only captures initial state).
   const currentTitle = useRef(title);
@@ -50,13 +167,6 @@ export default function BlockDetailContent({ block, projection, projectId, onRef
       }
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  useEffect(() => {
-    if (block.title !== savedTitle.current) {
-      setTitle(block.title);
-      savedTitle.current = block.title;
-    }
-  }, [block.title]);
 
   const blockId = block.id;
   const boardSlots = projection.slots.filter((s: Slot) => s.area === 'board');
@@ -84,6 +194,7 @@ export default function BlockDetailContent({ block, projection, projectId, onRef
     if (notes === savedNotes.current) return;
     await appendEvent(projectId, { type: 'BlockUpdated', payload: { blockId, notes } });
     savedNotes.current = notes;
+    await onRefresh();
   }
 
   async function saveTags(newTags: string[]) {
@@ -141,6 +252,27 @@ export default function BlockDetailContent({ block, projection, projectId, onRef
       payload: { blockId, fromSlot: block.boardSlot, toSlot: slotId },
     });
     await onRefresh();
+  }
+
+  async function toggleHistory() {
+    if (!historyOpen && historyItems === null) {
+      setHistoryLoading(true);
+      try {
+        const all = await getProjectEvents(projectId);
+        setHistoryItems(buildHistory(all, blockId));
+      } finally {
+        setHistoryLoading(false);
+      }
+    }
+    setHistoryOpen(v => !v);
+  }
+
+  function toggleDiff(id: string) {
+    setExpandedDiffs(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
   }
 
   return (
@@ -295,6 +427,73 @@ export default function BlockDetailContent({ block, projection, projectId, onRef
             <span>created {new Date(block.createdAt).toLocaleDateString()}</span>
             <span>·</span>
             <span>updated {new Date(block.updatedAt).toLocaleDateString()}</span>
+          </div>
+
+          <div className="block-detail-section">
+            <button className="block-detail-history-toggle" onClick={toggleHistory}>
+              <i className={`ti ti-chevron-${historyOpen ? 'down' : 'right'} block-detail-history-chevron`} />
+              history
+              {historyLoading && <span className="block-detail-history-loading"> loading…</span>}
+            </button>
+
+            {historyOpen && historyItems !== null && (
+              <div className="block-detail-history-list">
+                {historyItems.length === 0 ? (
+                  <span className="block-detail-history-empty">no history yet</span>
+                ) : historyItems.map(item => {
+                  const hasDiff = item.prevNotes !== undefined && item.nextNotes !== undefined;
+                  const isExpanded = expandedDiffs.has(item.id);
+                  const diffLines = hasDiff && isExpanded
+                    ? compactDiff(computeLineDiff(item.prevNotes!, item.nextNotes!))
+                    : null;
+
+                  const rowContent = (
+                    <>
+                      <span className="block-detail-history-date">
+                        {new Date(item.timestamp).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}
+                        {' '}
+                        {new Date(item.timestamp).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })}
+                      </span>
+                      <span className="block-detail-history-label">{item.label}</span>
+                      {hasDiff && (
+                        <i className={`ti ti-chevron-${isExpanded ? 'up' : 'down'} block-detail-history-chevron-inline`} />
+                      )}
+                    </>
+                  );
+
+                  return (
+                    <div key={item.id} className="block-detail-history-item">
+                      {hasDiff ? (
+                        <button
+                          className="block-detail-history-row block-detail-history-row-btn"
+                          onClick={() => toggleDiff(item.id)}
+                          title={isExpanded ? 'Hide diff' : 'Show diff'}
+                        >
+                          {rowContent}
+                        </button>
+                      ) : (
+                        <div className="block-detail-history-row">{rowContent}</div>
+                      )}
+                      {diffLines && diffLines.length > 0 && (
+                        <div className="block-detail-history-diff">
+                          {diffLines.map((line, i) => (
+                            <div key={i} className={`block-detail-history-diff-${line.kind}`}>
+                              {line.kind === 'add' ? '+ ' : line.kind === 'remove' ? '− ' : '  '}
+                              {line.line || ' '}
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                      {diffLines && diffLines.length === 0 && isExpanded && (
+                        <div className="block-detail-history-diff">
+                          <div className="block-detail-history-diff-context">  (no textual change)</div>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/web/src/index.css
+++ b/src/web/src/index.css
@@ -3126,3 +3126,126 @@ a.chapter-row-title:hover {
   color: var(--color-text-secondary);
   opacity: 0.7;
 }
+
+.block-detail-history-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  padding: 0;
+}
+
+.block-detail-history-toggle:hover {
+  color: var(--color-text-primary);
+}
+
+.block-detail-history-chevron {
+  font-size: 11px;
+}
+
+.block-detail-history-loading {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+  opacity: 0.6;
+}
+
+.block-detail-history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-top: 6px;
+  border-top: 1px solid var(--color-border);
+  margin-top: 4px;
+}
+
+.block-detail-history-empty {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  opacity: 0.5;
+}
+
+.block-detail-history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.block-detail-history-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.block-detail-history-date {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  opacity: 0.55;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.block-detail-history-label {
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  color: var(--color-text-secondary);
+  flex: 1;
+}
+
+.block-detail-history-row-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  padding: 2px 4px;
+  margin: 0 -4px;
+  border-radius: 3px;
+}
+
+.block-detail-history-row-btn:hover {
+  background: var(--color-surface);
+}
+
+.block-detail-history-chevron-inline {
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  opacity: 0.5;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.block-detail-history-diff {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 10px;
+  line-height: 1.6;
+  padding: 6px 8px;
+  border-radius: 4px;
+  background: var(--color-surface);
+  white-space: pre-wrap;
+  word-break: break-word;
+  margin-left: 12px;
+}
+
+.block-detail-history-diff-add {
+  color: #4a9a6b;
+}
+
+.block-detail-history-diff-remove {
+  color: #b85c5c;
+}
+
+.block-detail-history-diff-context {
+  color: var(--color-text-secondary);
+  opacity: 0.5;
+}

--- a/src/web/src/pages/author/BlockDetail.tsx
+++ b/src/web/src/pages/author/BlockDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import SiteBanner from '../../components/SiteBanner';
 import BlockDetailContent from '../../components/author/BlockDetailContent';
@@ -69,6 +69,14 @@ export default function BlockDetail() {
   }, [projectId]);
 
   useEffect(() => { load(); }, [load]);
+
+  // Silently reload when switching between blocks so the projection stays
+  // fresh — necessary when notes were saved on the previous card.
+  const initialBlockId = useRef(blockId);
+  useEffect(() => {
+    if (blockId === initialBlockId.current) return;
+    load();
+  }, [blockId, load]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -239,6 +247,7 @@ export default function BlockDetail() {
 
       {promotedChapter ? (
         <ChapterDetail
+          key={promotedChapter.id}
           block={block}
           chapter={promotedChapter}
           projection={projection}
@@ -256,6 +265,7 @@ export default function BlockDetail() {
             />
           )}
           <BlockDetailContent
+            key={block.id}
             block={block}
             projection={projection}
             projectId={projectId!}


### PR DESCRIPTION
There's a defect where note content gets overwritten when navigating between notes within the detail page -- for example:

* update Note 1 text
* navigate to Note 2
*    auto-save happens, saving Note 1 text to Note 2, resulting in data loss.


Defect has been fixed. Additionally, we have instituted a history view with a git-like diff view showing what notes changed and what the change was. It's painful, but possible to recover these corrupted notes.