### PR TITLE
ci: restore VITE_INITIAL_ADMIN_USERNAMES env on Deploy step

### DIFF
--- a/.github/workflows/azure-static-web-apps-lively-ocean-0d34a8310.yml
+++ b/.github/workflows/azure-static-web-apps-lively-ocean-0d34a8310.yml
@@ -42,6 +42,8 @@ jobs:
           output_location: dist
           app_build_command: "npm install && npm run build"
           api_build_command: "npm install && npm run build"
+        env:
+          VITE_INITIAL_ADMIN_USERNAMES: ${{ vars.VITE_INITIAL_ADMIN_USERNAMES }}
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'


### PR DESCRIPTION
The env var was only on the explicit 'Build web app' gate step, but Oryx's embedded app_build_command inside the Deploy action rebuilds the frontend independently. That second build (the one actually deployed) had no VITE_INITIAL_ADMIN_USERNAMES, so Vite baked in an empty admin whitelist — breaking admin login in production.