### PR TITLE
fix: gate author features on the author role, not the admin allowlist

### DIFF
--- a/src/api/src/functions/planning.ts
+++ b/src/api/src/functions/planning.ts
@@ -1,6 +1,6 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 import { randomUUID } from 'crypto';
-import { isAdmin, getCallerUsername } from '../lib/table-client';
+import { isAuthor, getCallerUsername } from '../lib/table-client';
 import {
   appendEvent, removeEvent, replayEvents, readEvents, getUserIndex, updateUserIndex,
   PersistedEvent, SlotArea,
@@ -82,7 +82,7 @@ const TEMPLATE_SLOTS: Record<string, Array<{ id: string; label: string; order: n
 // ── Handlers ──────────────────────────────────────────────────────────────────
 
 async function createProject(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
 
   const username = request.params.username;
   const caller = getCallerUsername(request);
@@ -144,7 +144,7 @@ async function createProject(request: HttpRequest, context: InvocationContext): 
 }
 
 async function listProjects(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
 
   const username = request.params.username;
   try {
@@ -157,7 +157,7 @@ async function listProjects(request: HttpRequest, context: InvocationContext): P
 }
 
 async function appendProjectEvent(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
 
   const projectId = request.params.projectId;
   const caller = getCallerUsername(request) ?? 'unknown';
@@ -189,7 +189,7 @@ async function appendProjectEvent(request: HttpRequest, context: InvocationConte
 }
 
 async function getProjection(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
 
   const projectId = request.params.projectId;
   try {
@@ -202,7 +202,7 @@ async function getProjection(request: HttpRequest, context: InvocationContext): 
 }
 
 async function getChapterDraft(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
   const { projectId, chapterId } = request.params;
   try {
     const { BlobServiceClient } = await import('@azure/storage-blob');
@@ -234,7 +234,7 @@ async function getChapterDraft(request: HttpRequest, context: InvocationContext)
 }
 
 async function saveChapterDraft(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
   const { projectId, chapterId } = request.params;
   const caller = getCallerUsername(request) ?? 'unknown';
   try {
@@ -297,7 +297,7 @@ async function saveChapterDraft(request: HttpRequest, context: InvocationContext
 }
 
 async function getChapterDraftHistory(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
   const { projectId, chapterId } = request.params;
   try {
     const { events } = await readEvents(projectId);
@@ -312,7 +312,7 @@ async function getChapterDraftHistory(request: HttpRequest, context: InvocationC
 }
 
 async function getChapterDraftSnapshot(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
   const { projectId, chapterId, snapshotId } = request.params;
   try {
     const { BlobServiceClient } = await import('@azure/storage-blob');
@@ -339,7 +339,7 @@ async function getChapterDraftSnapshot(request: HttpRequest, context: Invocation
 }
 
 async function getProjectEvents(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
 
   const projectId = request.params.projectId;
   try {
@@ -352,7 +352,7 @@ async function getProjectEvents(request: HttpRequest, context: InvocationContext
 }
 
 async function deleteChapterDraftSnapshot(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
-  if (!isAdmin(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
+  if (!isAuthor(request)) return { status: 401, jsonBody: { message: 'Unauthorized' } };
   const { projectId, chapterId, snapshotId } = request.params;
   try {
     const { events } = await readEvents(projectId);

--- a/src/api/src/lib/table-client.ts
+++ b/src/api/src/lib/table-client.ts
@@ -26,3 +26,16 @@ export function isAdmin(request: HttpRequest): boolean {
   const admins = (process.env.VITE_INITIAL_ADMIN_USERNAMES ?? '').split(',').map((u) => u.trim());
   return admins.includes(caller);
 }
+
+export function isAuthor(request: HttpRequest): boolean {
+  if (isDev) return true;
+  const header = request.headers.get('x-ms-client-principal');
+  if (!header) return false;
+  try {
+    const principal = JSON.parse(Buffer.from(header, 'base64').toString('utf-8'));
+    const roles: string[] = principal.userRoles ?? [];
+    return roles.includes('author');
+  } catch {
+    return false;
+  }
+}

--- a/src/web/src/components/AuthorLayout.tsx
+++ b/src/web/src/components/AuthorLayout.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 export default function AuthorLayout({ children, breadcrumb }: Props) {
-  const { user, isAdmin, loading } = useAuth();
+  const { user, isAuthor, loading } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -18,10 +18,10 @@ export default function AuthorLayout({ children, breadcrumb }: Props) {
       if (!import.meta.env.DEV) {
         window.location.href = `/.auth/login/github?post_login_redirect_uri=${encodeURIComponent(window.location.pathname)}`;
       }
-    } else if (!isAdmin) {
+    } else if (!isAuthor) {
       navigate('/unauthorized', { replace: true });
     }
-  }, [loading, user, isAdmin, navigate]);
+  }, [loading, user, isAuthor, navigate]);
 
   if (loading) return (
     <div className="author-shell" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
@@ -29,7 +29,7 @@ export default function AuthorLayout({ children, breadcrumb }: Props) {
     </div>
   );
 
-  if (!isAdmin) return null;
+  if (!isAuthor) return null;
 
   return (
     <div className="author-shell">


### PR DESCRIPTION
Authors and admins are mutually exclusive sets, but every planning API endpoint and AuthorLayout checked isAdmin() (the VITE_INITIAL_ADMIN_USERNAMES allowlist) instead of the author SWA role. A user invited as an author but not listed as an admin got 401s from the API and a 403 "closed to you" page client-side despite having the correct role.

Adds isAuthor() to table-client.ts, mirroring isAdmin() but checking x-ms-client-principal's userRoles for 'author' instead of the allowlist, and swaps all 10 isAdmin() gates in planning.ts plus AuthorLayout's gate over to it.